### PR TITLE
Fix race control util name

### DIFF
--- a/src/components/raceControl.tsx
+++ b/src/components/raceControl.tsx
@@ -1,7 +1,7 @@
 import { getRaceControlBySession } from "@/services/raceControl";
 import RaceControlItem from "./raceControlItem";
 import { orderRaceControl } from "@/utils/orderRaceControl";
-import adaptRaceControToTimeline from "@/utils/adaptRaceControToTimeline";
+import adaptRaceControlToTimeline from "@/utils/adaptRaceControlToTimeline";
 
 export type RaceControlProp = {
   session_key: string;
@@ -11,7 +11,7 @@ export type RaceControlProp = {
 const timeLineAdaptedRequest = async (sessionKey: string) => {
   const raceControlRequested = await getRaceControlBySession(sessionKey);
   const raceControlSorted = orderRaceControl(raceControlRequested);
-  const timeLineAdapted = adaptRaceControToTimeline(raceControlSorted);
+  const timeLineAdapted = adaptRaceControlToTimeline(raceControlSorted);
   return timeLineAdapted;
 };
 

--- a/src/utils/adaptRaceControlToTimeline.ts
+++ b/src/utils/adaptRaceControlToTimeline.ts
@@ -2,7 +2,7 @@ import { RaceControlTypeItem } from "@/types/RaceControlItem";
 import dayjs from "dayjs";
 const localizedFormat = require("dayjs/plugin/localizedFormat");
 dayjs.extend(localizedFormat);
-const adaptRaceControToTimeline = (raceControl: RaceControlTypeItem[]) => {
+const adaptRaceControlToTimeline = (raceControl: RaceControlTypeItem[]) => {
   return raceControl.map((race, index) => ({
     id: index,
     content: race.message,
@@ -13,4 +13,4 @@ const adaptRaceControToTimeline = (raceControl: RaceControlTypeItem[]) => {
   }));
 };
 
-export default adaptRaceControToTimeline;
+export default adaptRaceControlToTimeline;


### PR DESCRIPTION
## Summary
- rename utility `adaptRaceControToTimeline` => `adaptRaceControlToTimeline`
- update imports to the corrected file

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407a4e98b88325814c96dcfb56fcdd