### PR TITLE
Skip caching during live sessions

### DIFF
--- a/src/services/isSessionLive.ts
+++ b/src/services/isSessionLive.ts
@@ -1,0 +1,18 @@
+import { getRaces } from "./races";
+import isLiveSessionNow from "@/utils/isLiveSessionNow";
+
+/**
+ * Returns true if the session identified by `sessionKey` is
+ * currently running.
+ */
+export const isSessionLive = async (sessionKey: string): Promise<boolean> => {
+  try {
+    const races = await getRaces({ sessionKey });
+    const race = races?.[0];
+    if (!race) return false;
+    return isLiveSessionNow(new Date(race.date_start), new Date(race.date_end));
+  } catch (error) {
+    console.error("Error determining session live status", error);
+    return false;
+  }
+};

--- a/src/services/raceControl.ts
+++ b/src/services/raceControl.ts
@@ -1,6 +1,7 @@
 import { RaceControlTypeItem } from "@/types/RaceControlItem";
 import { Redis } from '@upstash/redis';
 import { CachedData, TTL_CACHE } from './cache';
+import { isSessionLive } from './isSessionLive';
 export const getRaceControlBySession = async (
   sessionKey: string
 ): Promise<RaceControlTypeItem[]> => {
@@ -10,10 +11,13 @@ export const getRaceControlBySession = async (
   const QUERIES = `?session_key=${sessionKey}`;
   const redis = Redis.fromEnv();
   try {
-    const result = await redis.get(key);
-    const parsedResult = result && typeof result === "string"  ? JSON.parse(result) as CachedData : result as CachedData;
-    if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
-      return parsedResult.data;
+    const live = await isSessionLive(sessionKey);
+    if (!live) {
+      const result = await redis.get(key);
+      const parsedResult = result && typeof result === "string"  ? JSON.parse(result) as CachedData : result as CachedData;
+      if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
+        return parsedResult.data;
+      }
     }
     const response = await fetch(API_ENDPOINT + SERVICE + QUERIES);
     const raceControlData = await response.json();
@@ -21,7 +25,9 @@ export const getRaceControlBySession = async (
     const responseData = {query: API_ENDPOINT + SERVICE + QUERIES, data: null}
     responseData.query = API_ENDPOINT + SERVICE + QUERIES;
     responseData.data = raceControlData;
-    await redis.set(key, JSON.stringify(responseData), {ex: TTL_CACHE});
+    if (!live) {
+      await redis.set(key, JSON.stringify(responseData), {ex: TTL_CACHE});
+    }
 
     return raceControlData;
   } catch (error) {

--- a/src/services/winnerByRace.ts
+++ b/src/services/winnerByRace.ts
@@ -1,29 +1,37 @@
 import { getDriver } from "./driver";
 import { Redis } from '@upstash/redis';
 import { CachedData, TTL_CACHE } from "./cache";
+import { isSessionLive } from "./isSessionLive";
 export const getWinnerByRace = async (sessionKey: string) => {
-  const key = `position_session_key_${sessionKey}_position_1`
+  const key = `position_session_key_${sessionKey}_position_1`;
   const API_ENDPOINT = process.env.API_ENDPOINT;
   const SERVICE = "position";
   const QUERIES = `?session_key=${sessionKey}&position<=1`;
   let racesData = [];
   const redis = Redis.fromEnv();
   try {
-    const result = await redis.get(key);
-    const parsedResult = result && typeof result === "string"  ? JSON.parse(result) as CachedData : result as CachedData;
-    if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
-      racesData = parsedResult.data;
-    } else {
+    const live = await isSessionLive(sessionKey);
+    if (!live) {
+      const result = await redis.get(key);
+      const parsedResult = result && typeof result === "string"  ? JSON.parse(result) as CachedData : result as CachedData;
+      if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
+        racesData = parsedResult.data;
+      } else {
+        const response = await fetch(API_ENDPOINT + SERVICE + QUERIES, {
+          next: { revalidate: 3600, tags: ["winners"] },
+        });
+        racesData = await response.json();
 
+        const responseData = {query: API_ENDPOINT + SERVICE + QUERIES, data: null};
+        responseData.query = API_ENDPOINT + SERVICE + QUERIES;
+        responseData.data = racesData;
+        await redis.set(key, JSON.stringify(responseData), {ex: TTL_CACHE});
+      }
+    } else {
       const response = await fetch(API_ENDPOINT + SERVICE + QUERIES, {
         next: { revalidate: 3600, tags: ["winners"] },
       });
       racesData = await response.json();
-
-      const responseData = {query: API_ENDPOINT + SERVICE + QUERIES, data: null}
-      responseData.query = API_ENDPOINT + SERVICE + QUERIES;
-      responseData.data = racesData
-      await redis.set(key, JSON.stringify(responseData), {ex: TTL_CACHE});
     }
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Summary
- add helper to check if a session is currently running
- bypass redis cache when a race session is live

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407f210d8483258034d8c10df95fc4