### PR TITLE
Improve pitstop grouping

### DIFF
--- a/src/components/pitstopItem.tsx
+++ b/src/components/pitstopItem.tsx
@@ -55,10 +55,10 @@ export default function PitstopItem({ person }: any) {
           {person.name}
         </p>
         <p className="mt-1 truncate text-xs leading-5 text-gray-500">
-          Lap number: {person.lap_number}
+          Pitstops: {person.pitstops}
         </p>
         <p className="mt-1 truncate text-xs leading-5 text-gray-500">
-          Duration: {person.pit_duration} Seconds
+          Total: {person.total_duration} Seconds
         </p>
       </div>
     </li>

--- a/src/utils/adaptPitstops.test.ts
+++ b/src/utils/adaptPitstops.test.ts
@@ -1,0 +1,45 @@
+import adaptPitstops from './adaptPitstops';
+
+describe('adaptPitstops', () => {
+  it('groups pitstops by driver and sums durations', () => {
+    const data = [
+      {
+        driver_number: 44,
+        lap_number: 10,
+        pit_duration: '2.5',
+        driver: { full_name: 'Driver A', headshot_url: '/a.png' },
+      },
+      {
+        driver_number: 44,
+        lap_number: 20,
+        pit_duration: '3',
+        driver: { full_name: 'Driver A', headshot_url: '/a.png' },
+      },
+      {
+        driver_number: 55,
+        lap_number: 15,
+        pit_duration: '4',
+        driver: { full_name: 'Driver B', headshot_url: '/b.png' },
+      },
+    ];
+
+    const result = adaptPitstops(data);
+
+    expect(result).toEqual([
+      {
+        key: '44',
+        name: 'Driver A',
+        imageUrl: '/a.png',
+        pitstops: 2,
+        total_duration: 5.5,
+      },
+      {
+        key: '55',
+        name: 'Driver B',
+        imageUrl: '/b.png',
+        pitstops: 1,
+        total_duration: 4,
+      },
+    ]);
+  });
+});

--- a/src/utils/adaptPitstops.ts
+++ b/src/utils/adaptPitstops.ts
@@ -1,13 +1,22 @@
 const adaptPitstops = (pitstops: any[]) => {
-  return pitstops.map((pitstop: any) => {
-    return {
-      key: `${pitstop.driver_number}-${pitstop.lap_number}`,
-      name: pitstop.driver.full_name,
-      imageUrl: pitstop.driver.headshot_url,
-      lap_number: pitstop.lap_number,
-      pit_duration: pitstop.pit_duration,
-    };
+  const grouped = new Map<number, any>();
+  pitstops.forEach((pitstop: any) => {
+    const driverId = pitstop.driver_number;
+    if (!grouped.has(driverId)) {
+      grouped.set(driverId, {
+        key: `${driverId}`,
+        name: pitstop.driver.full_name,
+        imageUrl: pitstop.driver.headshot_url,
+        pitstops: 0,
+        total_duration: 0,
+      });
+    }
+    const data = grouped.get(driverId);
+    data.pitstops += 1;
+    data.total_duration += Number(pitstop.pit_duration);
+    grouped.set(driverId, data);
   });
+  return Array.from(grouped.values());
 };
 
 export default adaptPitstops;


### PR DESCRIPTION
## Summary
- group pitstops by driver and accumulate times
- show total pitstops and time per driver in UI
- add tests for adaptPitstops

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684081d11d048325845392b61093b510