### PR TITLE
Use precise float addition in pitstop parser

### DIFF
--- a/src/utils/adaptPitstops.ts
+++ b/src/utils/adaptPitstops.ts
@@ -1,3 +1,5 @@
+import { add } from './big';
+
 const adaptPitstops = (pitstops: any[]) => {
   const grouped = new Map<number, any>();
   pitstops.forEach((pitstop: any) => {
@@ -13,7 +15,7 @@ const adaptPitstops = (pitstops: any[]) => {
     }
     const data = grouped.get(driverId);
     data.pitstops += 1;
-    data.total_duration += Number(pitstop.pit_duration);
+    data.total_duration = add(data.total_duration, pitstop.pit_duration);
     grouped.set(driverId, data);
   });
   return Array.from(grouped.values());

--- a/src/utils/big.ts
+++ b/src/utils/big.ts
@@ -1,0 +1,27 @@
+export function add(a: number | string, b: number | string): number {
+  const aStr = a.toString();
+  const bStr = b.toString();
+
+  const aDec = aStr.includes('.') ? aStr.split('.')[1].length : 0;
+  const bDec = bStr.includes('.') ? bStr.split('.')[1].length : 0;
+  const decimals = Math.max(aDec, bDec);
+
+  const factor = BigInt(10) ** BigInt(decimals);
+
+  const [aInt, aFrac = ''] = aStr.split('.');
+  const [bInt, bFrac = ''] = bStr.split('.');
+
+  const aBig = BigInt(aInt) * factor + BigInt((aFrac.padEnd(decimals, '0')).slice(0, decimals));
+  const bBig = BigInt(bInt) * factor + BigInt((bFrac.padEnd(decimals, '0')).slice(0, decimals));
+
+  const sum = aBig + bBig;
+
+  const intPart = sum / factor;
+  const fracPart = sum % factor;
+
+  const fracStr = fracPart.toString().padStart(decimals, '0').replace(/0+$/, '');
+
+  return fracStr ? parseFloat(`${intPart.toString()}.${fracStr}`) : Number(intPart);
+}
+
+export default { add };


### PR DESCRIPTION
## Summary
- add a simple Big.js-style addition helper
- use the helper for summing pitstop durations

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840cbc21d5c8325ace5d55225112168