### PR TITLE
Add season year selector

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { FlagValues } from "@vercel/flags/react";
 import { getFlags } from "./getFlags";
 import { orderRacesLastest } from "@/utils/orderRacesByLastest";
 import TabRaces from "@/components/tabRaces";
+import YearSelect from "@/components/yearSelect";
 export const revalidate = 3600;
 
 async function ConfidentialFlagValues({ values }: { readonly values: any }) {
@@ -25,7 +26,10 @@ const Home = async ({ searchParams }: any) => {
   const sessionType = searchParamsAwaited?.sessionType
     ? (searchParamsAwaited?.sessionType as string)
     : undefined;
-  const races = await getRaces({ sessionType });
+  const year = searchParamsAwaited?.year
+    ? parseInt(searchParamsAwaited?.year as string)
+    : undefined;
+  const races = await getRaces({ sessionType, year });
   const racesOrdered = orderRacesLastest(
     races,
     sessionType,
@@ -45,6 +49,8 @@ const Home = async ({ searchParams }: any) => {
         </Suspense>
 
         {values.showSearchInput && <SearchInput />}
+
+        <YearSelect />
 
         <TabRaces sessionTypes={["Practice", "Qualifying", "Race"]} />
 

--- a/src/components/tabRaces.tsx
+++ b/src/components/tabRaces.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 interface TabRacesProps {
   sessionTypes: string[];
@@ -8,13 +8,20 @@ interface TabRacesProps {
 
 export default function TabRaces(props: TabRacesProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   return (
     <div className="relative  mx-auto gap-1 rounded-lg border border-stroke bg-white p-1 dark:border-dark-stroke dark:bg-white/[.02] mb-4 text-center w-full max-w-xl">
       {props.sessionTypes.map((sessionType, index) => (
         <button
           key={index}
           className="inline-flex h-8 items-center justify-center rounded-md px-3 text-sm font-medium duration-200 text-dark-5 hover:bg-black hover:text-white dark:text-black "
-          onClick={() => router.push("?sessionType=" + sessionType)}
+          onClick={() => {
+            const params = new URLSearchParams(
+              Array.from(searchParams.entries())
+            );
+            params.set("sessionType", sessionType);
+            router.push("?" + params.toString());
+          }}
         >
           {sessionType}
         </button>

--- a/src/components/yearSelect.tsx
+++ b/src/components/yearSelect.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { currentYear } from "@/utils/constants";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function YearSelect() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const selectedYear = searchParams.get("year") || String(currentYear);
+  const years = Array.from({ length: 5 }, (_, i) => String(currentYear - i));
+
+  const handleChange = (year: string) => {
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    params.set("year", year);
+    router.push("?" + params.toString());
+  };
+
+  return (
+    <div className="relative mx-auto w-full max-w-xl mb-4">
+      <select
+        className="w-full rounded-lg border border-stroke p-2 text-sm"
+        value={selectedYear}
+        onChange={(e) => handleChange(e.target.value)}
+      >
+        {years.map((year) => (
+          <option key={year} value={year}>
+            {year}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/services/races.ts
+++ b/src/services/races.ts
@@ -5,22 +5,24 @@ import { CachedData, TTL_CACHE } from "./cache";
 interface GetRaceType {
   sessionKey?: string;
   sessionType?: string;
+  year?: number;
 }
 
 export const getRaces = async (params: GetRaceType) => {
-  let key = `racesResponse_year_${currentYear}`
+  const year = params.year ?? currentYear;
+  let key = `racesResponse_year_${year}`;
   const API_ENDPOINT = process.env.API_ENDPOINT;
   const redis = Redis.fromEnv();
 
   const SERVICE = "sessions";
-  let QUERIES = `?year=${currentYear}`;
+  let QUERIES = `?year=${year}`;
   if (params.sessionKey) {
     QUERIES += "&session_key=" + params.sessionKey;
-    key = `racesResponse_session_key_${params.sessionKey}`
+    key = `racesResponse_session_key_${params.sessionKey}`;
   }
   if (params.sessionType) {
     QUERIES += "&session_type=" + params.sessionType;
-     key = `racesResponse_session_type_${params.sessionType}`
+    key = `racesResponse_session_type_${params.sessionType}_${year}`;
   }
   try {
     const result = await redis.get(key);


### PR DESCRIPTION
## Summary
- allow selecting year of season
- support filtering races by selected year
- add a year selector component
- preserve selected year when switching session types

## Testing
- `pnpm install` *(fails: Forbidden - 403)*
- `pnpm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bbca35b0832592ebb7461fcb775b