### PR TITLE
Improve caching strategy to reduce API rate-limit exposure

### DIFF
--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -2,6 +2,7 @@ export interface CachedData {
     query: string;
     data: any;
   }
-  
-export const TTL_CACHE = 3600*24;
+
+export const TTL_CACHE = 3600 * 24; // 24 hours for completed sessions
+export const TTL_LIVE = 30;         // 30 seconds for live sessions
   

--- a/src/services/driver.ts
+++ b/src/services/driver.ts
@@ -1,30 +1,49 @@
+import { cache } from 'react';
 import { Redis } from '@upstash/redis';
 import { CachedData, TTL_CACHE } from './cache';
+import { fetchWithRetry } from '@/utils/fetchWithRetry';
 
-export const getDriver = async (driverNumber: number | string) => {
-  const key = `drivers_driver_number_${driverNumber}`
+/**
+ * Fetches a single driver by number.
+ *
+ * Wrapped with React.cache() so that multiple calls with the same driver
+ * number within a single server-render pass share one result — eliminating
+ * duplicate Redis lookups and API calls for the same driver (e.g. when a
+ * driver has several pit stops in a race).
+ */
+const fetchDriver = cache(async (driverNumber: number | string) => {
+  const key = `drivers_driver_number_${driverNumber}`;
   const redis = Redis.fromEnv();
   const API_ENDPOINT = process.env.API_ENDPOINT;
   const SERVICE = "drivers";
   const QUERIES = `?driver_number=${driverNumber}`;
   try {
     const result = await redis.get(key);
-    const parsedResult = result && typeof result === "string"  ? JSON.parse(result) as CachedData : result as CachedData;
+    const parsedResult =
+      result && typeof result === "string"
+        ? (JSON.parse(result) as CachedData)
+        : (result as CachedData);
     if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
       return parsedResult.data;
     }
-    const response = await fetch(API_ENDPOINT + SERVICE + QUERIES, {
+
+    const response = await fetchWithRetry(API_ENDPOINT + SERVICE + QUERIES, {
       cache: "force-cache",
     });
-    const responseData = {query: API_ENDPOINT + SERVICE + QUERIES, data: null}
-    const racesData = await response.json();
-    responseData.query = API_ENDPOINT + SERVICE + QUERIES;
-    responseData.data = racesData.at(0);
-    await redis.set(key, JSON.stringify(responseData), {ex: TTL_CACHE});
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
-    return racesData.at(0);
+    const racesData = await response.json();
+    const driver = racesData.at(0);
+    await redis.set(
+      key,
+      JSON.stringify({ query: API_ENDPOINT + SERVICE + QUERIES, data: driver }),
+      { ex: TTL_CACHE }
+    );
+    return driver;
   } catch (error) {
     console.error(error);
+    return null;
   }
-  return null;
-};
+});
+
+export const getDriver = fetchDriver;

--- a/src/services/pitstops.ts
+++ b/src/services/pitstops.ts
@@ -1,7 +1,8 @@
 import { getDriver } from "./driver";
 import { Redis } from '@upstash/redis';
-import { CachedData, TTL_CACHE } from './cache';
+import { CachedData, TTL_CACHE, TTL_LIVE } from './cache';
 import { isSessionLive } from './isSessionLive';
+import { fetchWithRetry } from '@/utils/fetchWithRetry';
 
 interface PitstopData {
   driver_number: number;
@@ -10,7 +11,7 @@ interface PitstopData {
 }
 
 export const getPitstops = async (sessionKey: string) => {
-  const key = `pit_session_key_${sessionKey}`
+  const key = `pit_session_key_${sessionKey}`;
   const redis = Redis.fromEnv();
   const API_ENDPOINT = process.env.API_ENDPOINT;
   const SERVICE = "pit";
@@ -18,35 +19,48 @@ export const getPitstops = async (sessionKey: string) => {
   let raceControlData: PitstopData[] = [];
   try {
     const live = await isSessionLive(sessionKey);
-    if (!live) {
-      const result = await redis.get(key);
-      const parsedResult = result && typeof result === "string"  ? JSON.parse(result) as CachedData : result as CachedData;
-      if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
-        return parsedResult.data;
-      }
+
+    // Always check cache first.
+    // Live sessions write with TTL_LIVE (30 s) so stale entries expire quickly
+    // while still protecting the API from hammering on every render.
+    const result = await redis.get(key);
+    const parsedResult =
+      result && typeof result === "string"
+        ? (JSON.parse(result) as CachedData)
+        : (result as CachedData);
+    if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
+      return parsedResult.data;
     }
 
-    
-
-    const response = await fetch(API_ENDPOINT + SERVICE + QUERIES);
-
+    const response = await fetchWithRetry(API_ENDPOINT + SERVICE + QUERIES);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
     raceControlData = await response.json();
-    for (let i = 0; i < raceControlData.length; i++) {
-      const driver = await getDriver(raceControlData[i].driver_number);
-      raceControlData[i] = { ...raceControlData[i], driver };
-    }
 
-    const responseData: CachedData = {query: API_ENDPOINT + SERVICE + QUERIES, data: null}
-    responseData.query = API_ENDPOINT + SERVICE + QUERIES;
-    responseData.data = raceControlData;
-    if (!live) {
-      await redis.set(key, JSON.stringify(responseData), {ex: TTL_CACHE});
-    }
+    // Deduplicate driver numbers and fetch all in parallel.
+    // React.cache() in getDriver() ensures each unique driver is only fetched
+    // once per render, even if multiple pit stops share the same driver.
+    const uniqueDriverNumbers = [
+      ...new Set(raceControlData.map((p) => p.driver_number)),
+    ];
+    const driverEntries = await Promise.all(
+      uniqueDriverNumbers.map(async (num) => [num, await getDriver(num)] as const)
+    );
+    const driverMap = new Map(driverEntries);
 
+    raceControlData = raceControlData.map((pitstop) => ({
+      ...pitstop,
+      driver: driverMap.get(pitstop.driver_number),
+    }));
+
+    const ttl = live ? TTL_LIVE : TTL_CACHE;
+    await redis.set(
+      key,
+      JSON.stringify({ query: API_ENDPOINT + SERVICE + QUERIES, data: raceControlData }),
+      { ex: ttl }
+    );
   } catch (error) {
     console.error(error);
   }
-
 
   return raceControlData;
 };

--- a/src/services/raceControl.ts
+++ b/src/services/raceControl.ts
@@ -1,33 +1,42 @@
 import { RaceControlTypeItem } from "@/types/RaceControlItem";
 import { Redis } from '@upstash/redis';
-import { CachedData, TTL_CACHE } from './cache';
+import { CachedData, TTL_CACHE, TTL_LIVE } from './cache';
 import { isSessionLive } from './isSessionLive';
+import { fetchWithRetry } from '@/utils/fetchWithRetry';
+
 export const getRaceControlBySession = async (
   sessionKey: string
 ): Promise<RaceControlTypeItem[]> => {
-  const key = `race_control_session_key_${sessionKey}`
+  const key = `race_control_session_key_${sessionKey}`;
   const API_ENDPOINT = process.env.API_ENDPOINT;
   const SERVICE = "race_control";
   const QUERIES = `?session_key=${sessionKey}`;
   const redis = Redis.fromEnv();
   try {
     const live = await isSessionLive(sessionKey);
-    if (!live) {
-      const result = await redis.get(key);
-      const parsedResult = result && typeof result === "string"  ? JSON.parse(result) as CachedData : result as CachedData;
-      if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
-        return parsedResult.data;
-      }
+
+    // Always check cache first.
+    // Live sessions are stored with TTL_LIVE (30 s) so entries auto-expire,
+    // ensuring fresh data without bypassing the cache on every render.
+    const result = await redis.get(key);
+    const parsedResult =
+      result && typeof result === "string"
+        ? (JSON.parse(result) as CachedData)
+        : (result as CachedData);
+    if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
+      return parsedResult.data;
     }
-    const response = await fetch(API_ENDPOINT + SERVICE + QUERIES);
+
+    const response = await fetchWithRetry(API_ENDPOINT + SERVICE + QUERIES);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const raceControlData = await response.json();
 
-    const responseData = {query: API_ENDPOINT + SERVICE + QUERIES, data: null}
-    responseData.query = API_ENDPOINT + SERVICE + QUERIES;
-    responseData.data = raceControlData;
-    if (!live) {
-      await redis.set(key, JSON.stringify(responseData), {ex: TTL_CACHE});
-    }
+    const ttl = live ? TTL_LIVE : TTL_CACHE;
+    await redis.set(
+      key,
+      JSON.stringify({ query: API_ENDPOINT + SERVICE + QUERIES, data: raceControlData }),
+      { ex: ttl }
+    );
 
     return raceControlData;
   } catch (error) {

--- a/src/services/winnerByRace.ts
+++ b/src/services/winnerByRace.ts
@@ -1,7 +1,9 @@
 import { getDriver } from "./driver";
 import { Redis } from '@upstash/redis';
-import { CachedData, TTL_CACHE } from "./cache";
+import { CachedData, TTL_CACHE, TTL_LIVE } from "./cache";
 import { isSessionLive } from "./isSessionLive";
+import { fetchWithRetry } from "@/utils/fetchWithRetry";
+
 export const getWinnerByRace = async (sessionKey: string) => {
   const key = `position_session_key_${sessionKey}_position_1`;
   const API_ENDPOINT = process.env.API_ENDPOINT;
@@ -11,34 +13,37 @@ export const getWinnerByRace = async (sessionKey: string) => {
   const redis = Redis.fromEnv();
   try {
     const live = await isSessionLive(sessionKey);
-    if (!live) {
-      const result = await redis.get(key);
-      const parsedResult = result && typeof result === "string"  ? JSON.parse(result) as CachedData : result as CachedData;
-      if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
-        racesData = parsedResult.data;
-      } else {
-        const response = await fetch(API_ENDPOINT + SERVICE + QUERIES, {
-          next: { revalidate: 3600, tags: ["winners"] },
-        });
-        racesData = await response.json();
 
-        const responseData = {query: API_ENDPOINT + SERVICE + QUERIES, data: null};
-        responseData.query = API_ENDPOINT + SERVICE + QUERIES;
-        responseData.data = racesData;
-        await redis.set(key, JSON.stringify(responseData), {ex: TTL_CACHE});
-      }
+    // Always check cache first.
+    // Live sessions write with TTL_LIVE (30 s) so fresh position data is
+    // fetched at most once per 30 s rather than on every page render.
+    const result = await redis.get(key);
+    const parsedResult =
+      result && typeof result === "string"
+        ? (JSON.parse(result) as CachedData)
+        : (result as CachedData);
+
+    if (parsedResult && parsedResult.query === API_ENDPOINT + SERVICE + QUERIES) {
+      racesData = parsedResult.data;
     } else {
-      const response = await fetch(API_ENDPOINT + SERVICE + QUERIES, {
+      const response = await fetchWithRetry(API_ENDPOINT + SERVICE + QUERIES, {
         next: { revalidate: 3600, tags: ["winners"] },
       });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
       racesData = await response.json();
+
+      const ttl = live ? TTL_LIVE : TTL_CACHE;
+      await redis.set(
+        key,
+        JSON.stringify({ query: API_ENDPOINT + SERVICE + QUERIES, data: racesData }),
+        { ex: ttl }
+      );
     }
   } catch (error) {
     console.error(error);
   }
 
   const winnerDriver = racesData.at(-1);
-
   let driver = null;
   if (winnerDriver) {
     driver = await getDriver(winnerDriver.driver_number);

--- a/src/utils/fetchWithRetry.ts
+++ b/src/utils/fetchWithRetry.ts
@@ -1,0 +1,38 @@
+// HTTP status codes that are safe to retry (rate limit + server errors)
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+/**
+ * Wraps fetch with exponential-backoff retry logic.
+ * Retries on network failures and RETRYABLE_STATUSES.
+ * Delays: 500 ms → 1 000 ms → 2 000 ms (maxRetries = 3).
+ */
+export async function fetchWithRetry(
+  url: string,
+  options?: RequestInit,
+  maxRetries = 3
+): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, options);
+
+      // Return immediately on success or a non-retryable error status
+      if (response.ok || !RETRYABLE_STATUSES.has(response.status)) {
+        return response;
+      }
+
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (err) {
+      // Network-level failure (DNS, timeout, etc.)
+      lastError = err;
+    }
+
+    if (attempt < maxRetries) {
+      const delay = Math.pow(2, attempt) * 500; // 500 ms, 1 000 ms, 2 000 ms
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
Four targeted changes working together:

1. React.cache() on getDriver — memoises per render pass so multiple pit stops from the same driver produce exactly one Redis/API call instead of N.

2. Parallel unique-driver fetching in getPitstops — replace the sequential for-await loop with Promise.all over deduplicated driver numbers, cutting wall-clock time and concurrent request count on cache misses.

3. Short-TTL caching for live sessions (TTL_LIVE = 30 s) — instead of bypassing Redis entirely, live sessions now write with a 30-second TTL. The API is hit at most once per 30 s per session, regardless of how many concurrent renders happen during a live race.

4. fetchWithRetry utility — wraps fetch with exponential-backoff retries (500 ms → 1 000 ms → 2 000 ms) on 429/5xx and network failures, so transient rate-limit responses are recovered automatically.

https://claude.ai/code/session_01T9NHprsufVV9G7xEmYJpiE