### PR TITLE
feat: atomic Lua-based rate limiting with iterative backoff and jitter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,7 @@ module.exports = {
   transform: {
     "^.+\\.(t|j)sx?$": "@swc/jest",
   },
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
 };

--- a/src/services/pitstop.test.ts
+++ b/src/services/pitstop.test.ts
@@ -7,6 +7,8 @@ jest.mock("@upstash/redis", () => ({
     fromEnv: jest.fn().mockReturnValue({
       get: jest.fn().mockResolvedValue(null),
       set: jest.fn().mockResolvedValue(undefined),
+      // Always grant a rate-limit slot so tests don't block on Redis.
+      eval: jest.fn().mockResolvedValue(1),
     }),
   },
 }));

--- a/src/services/pitstop.test.ts
+++ b/src/services/pitstop.test.ts
@@ -1,4 +1,6 @@
-import { jest } from "@jest/globals";
+// Import jest under an alias so the global `jest` remains accessible
+// inside jest.mock() factories (which @swc/jest hoists before imports run).
+import { jest as jestGlobals } from "@jest/globals";
 import { getPitstops } from "./pitstops";
 import { getDriver } from "./driver";
 
@@ -18,14 +20,15 @@ jest.mock("./driver", () => ({
 }));
 
 describe("getPitstops", () => {
-  let fetchSpy: jest.SpiedFunction<typeof fetch>;
+  let fetchSpy: jestGlobals.SpiedFunction<typeof fetch>;
 
   beforeEach(() => {
-    fetchSpy = jest.spyOn(global, "fetch");
+    fetchSpy = jestGlobals.spyOn(global, "fetch");
+    (getDriver as jestGlobals.Mock).mockResolvedValue({ code: "DRV" });
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    jestGlobals.restoreAllMocks();
   });
 
   it("returns parsed pit stop entries", async () => {
@@ -37,10 +40,9 @@ describe("getPitstops", () => {
     ];
 
     fetchSpy.mockResolvedValue({
+      ok: true,
       json: jest.fn().mockResolvedValue(sampleResponse),
     } as unknown as Response);
-
-    (getDriver as jest.Mock).mockResolvedValue({ code: "DRV" });
 
     const data = await getPitstops("9507");
 

--- a/src/services/pitstops.ts
+++ b/src/services/pitstops.ts
@@ -31,6 +31,10 @@ export const getPitstops = async (sessionKey: string) => {
 
     const response = await rateLimitedFetch(API_ENDPOINT + SERVICE + QUERIES);
 
+    if (!response.ok) {
+      throw new Error(`API Error: ${response.status}`);
+    }
+
     raceControlData = await response.json();
 
     // Fetch each unique driver once in parallel, then attach to all matching pitstops

--- a/src/services/rateLimiter.ts
+++ b/src/services/rateLimiter.ts
@@ -3,12 +3,14 @@
  *   - Max 3 requests per second
  *   - Max 30 requests per minute
  *
- * Uses Redis time-bucketed counters so limits are enforced across all
- * Cloudflare Worker instances (unlike the previous in-memory approach,
- * which reset on every cold start / new isolate).
+ * Uses a Lua script executed atomically in Redis so the check-and-increment is
+ * a single operation — no race conditions across Cloudflare Worker instances.
  *
- * On a 429 response the fetch is retried with exponential backoff up to
- * MAX_RETRIES times, honouring the Retry-After header when present.
+ * Slot acquisition is iterative (not recursive) with random jitter to prevent
+ * a thundering-herd when many workers become unblocked at the same moment.
+ *
+ * On a 429 response the fetch is retried with exponential backoff + jitter up
+ * to MAX_RETRIES times, honouring the Retry-After header when present.
  */
 
 import { Redis } from '@upstash/redis';
@@ -16,42 +18,74 @@ import { Redis } from '@upstash/redis';
 const MAX_PER_SECOND = 3;
 const MAX_PER_MINUTE = 30;
 const MAX_RETRIES = 5;
+const MAX_SLOT_ATTEMPTS = 20;
 
-async function acquireSlot(redis: Redis): Promise<void> {
-  const now = Date.now();
-  const secondKey = `rl:s:${Math.floor(now / 1_000)}`;
-  const minuteKey = `rl:m:${Math.floor(now / 60_000)}`;
+/**
+ * Atomically checks both rate-limit counters and, only if both are under their
+ * caps, increments them and sets their TTL in the same Lua transaction.
+ *
+ * Returns 1 when the slot is granted, 0 when the caller must wait.
+ */
+const ACQUIRE_SCRIPT = `
+local second_key = KEYS[1]
+local minute_key = KEYS[2]
+local max_per_second = tonumber(ARGV[1])
+local max_per_minute = tonumber(ARGV[2])
 
-  // Atomically increment both counters in a single pipeline round-trip
-  const [perSecond, , perMinute] = (await redis
-    .pipeline()
-    .incr(secondKey)
-    .expire(secondKey, 2)
-    .incr(minuteKey)
-    .expire(minuteKey, 120)
-    .exec()) as [number, number, number, number];
+local per_second = tonumber(redis.call('GET', second_key)) or 0
+local per_minute = tonumber(redis.call('GET', minute_key)) or 0
 
-  if (perSecond > MAX_PER_SECOND || perMinute > MAX_PER_MINUTE) {
-    // Release the slot we just claimed
-    await redis.pipeline().decr(secondKey).decr(minuteKey).exec();
+if per_second >= max_per_second or per_minute >= max_per_minute then
+  return 0
+end
 
-    // Wait until the limiting bucket rolls over
-    const waitMs =
-      perSecond > MAX_PER_SECOND
-        ? 1_000 - (now % 1_000) + 50
-        : 60_000 - (now % 60_000) + 50;
+redis.call('INCR', second_key)
+redis.call('EXPIRE', second_key, 2)
+redis.call('INCR', minute_key)
+redis.call('EXPIRE', minute_key, 120)
+return 1
+`;
 
+// Lazily initialised singleton — avoids reconstructing the client on every call.
+let _redis: Redis | null = null;
+function getRedis(): Redis {
+  if (!_redis) _redis = Redis.fromEnv();
+  return _redis;
+}
+
+async function acquireSlot(): Promise<void> {
+  const redis = getRedis();
+
+  for (let attempt = 0; attempt < MAX_SLOT_ATTEMPTS; attempt++) {
+    const now = Date.now();
+    const secondKey = `rl:s:${Math.floor(now / 1_000)}`;
+    const minuteKey = `rl:m:${Math.floor(now / 60_000)}`;
+
+    const acquired = await redis.eval(
+      ACQUIRE_SCRIPT,
+      [secondKey, minuteKey],
+      [String(MAX_PER_SECOND), String(MAX_PER_MINUTE)]
+    );
+
+    if (acquired === 1) return;
+
+    // Wait until the current second bucket rolls over, plus random jitter so
+    // workers don't all retry simultaneously (thundering herd).
+    const jitterMs = Math.random() * 100;
+    const waitMs = 1_000 - (Date.now() % 1_000) + 50 + jitterMs;
     await new Promise((resolve) => setTimeout(resolve, waitMs));
-    return acquireSlot(redis);
   }
+
+  throw new Error(
+    `[rateLimiter] Could not acquire rate limit slot after ${MAX_SLOT_ATTEMPTS} attempts`
+  );
 }
 
 export async function rateLimitedFetch(
   url: string,
   options?: RequestInit
 ): Promise<Response> {
-  const redis = Redis.fromEnv();
-  await acquireSlot(redis);
+  await acquireSlot();
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const response = await fetch(url, options);
@@ -60,17 +94,18 @@ export async function rateLimitedFetch(
       return response;
     }
 
-    // Honour Retry-After when provided, otherwise use exponential backoff
+    // Honour Retry-After when provided, otherwise use exponential backoff + jitter.
     const retryAfter = response.headers.get('Retry-After');
-    const waitMs = retryAfter
+    const baseWait = retryAfter
       ? parseInt(retryAfter, 10) * 1_000
       : Math.min(500 * Math.pow(2, attempt), 30_000);
+    const waitMs = baseWait + Math.random() * 500;
 
     console.warn(
-      `[rateLimiter] 429 on attempt ${attempt + 1}/${MAX_RETRIES}. Retrying in ${waitMs}ms.`
+      `[rateLimiter] 429 on attempt ${attempt + 1}/${MAX_RETRIES}. Retrying in ${Math.round(waitMs)}ms.`
     );
     await new Promise((resolve) => setTimeout(resolve, waitMs));
-    await acquireSlot(redis);
+    await acquireSlot();
   }
 
   throw new Error(

--- a/src/utils/adaptPitstops.test.ts
+++ b/src/utils/adaptPitstops.test.ts
@@ -42,4 +42,27 @@ describe('adaptPitstops', () => {
       },
     ]);
   });
+
+  it('falls back gracefully when driver data is missing', () => {
+    const data = [
+      {
+        driver_number: 33,
+        lap_number: 5,
+        pit_duration: '2',
+        driver: null,
+      },
+    ];
+
+    const result = adaptPitstops(data);
+
+    expect(result).toEqual([
+      {
+        key: '33',
+        name: 'Driver #33',
+        imageUrl: null,
+        pitstops: 1,
+        total_duration: 2,
+      },
+    ]);
+  });
 });

--- a/src/utils/adaptPitstops.ts
+++ b/src/utils/adaptPitstops.ts
@@ -7,8 +7,8 @@ const adaptPitstops = (pitstops: any[]) => {
     if (!grouped.has(driverId)) {
       grouped.set(driverId, {
         key: `${driverId}`,
-        name: pitstop.driver.full_name,
-        imageUrl: pitstop.driver.headshot_url,
+        name: pitstop.driver?.full_name ?? `Driver #${driverId}`,
+        imageUrl: pitstop.driver?.headshot_url ?? null,
         pitstops: 0,
         total_duration: 0,
       });


### PR DESCRIPTION
Replace the pipeline incr/decr pattern with a Lua script so the
check-and-increment is a single atomic Redis operation, eliminating
the race condition where concurrent workers could all overshoot the
per-second/per-minute caps.

Additional improvements:
- Iterative acquireSlot loop instead of recursion (no stack-overflow risk)
- Random jitter on retry wait to avoid thundering herd
- Jitter added to 429 exponential backoff for the same reason
- Singleton Redis client (lazy init) avoids re-constructing on every call
- Update pitstop.test.ts mock to expose `eval` so tests pass

https://claude.ai/code/session_013ejF1oqa9UbAdpTvkNMVXu