### PR TITLE
feat: Timing Tower dark motorsport redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+pnpm dev          # Dev server with Turbopack
+pnpm build        # Next.js production build
+pnpm lint         # ESLint
+pnpm test         # Jest (all tests)
+pnpm test -- --testPathPattern=<file>  # Run a single test file
+```
+
+**Cloudflare deployment:**
+```bash
+pnpm build
+pnpm exec @opennextjs/cloudflare build
+pnpm exec wrangler deploy
+```
+
+## Architecture
+
+**Next.js 16 App Router** deployed to **Cloudflare Workers** via `@opennextjs/cloudflare` + Wrangler.
+
+### Data flow
+1. Pages are React Server Components that call service functions directly
+2. Services (`src/services/`) fetch from an external REST API (`API_ENDPOINT` env var) with endpoints: `sessions`, `race_control`, `pit`, `drivers`, `position`
+3. Responses are cached in **Upstash Redis** (24h TTL via `TTL_CACHE`). Live sessions bypass Redis (checked via `isSessionLive()`)
+4. Client components handle interactivity; server components handle all data fetching
+
+### Key routes
+- `/` — Lists sessions; filterable by `?sessionType=` query param; ISR with `revalidate = 3600`
+- `/session/[id]` — Session detail; `?selectedTab=1` = Race Control, `?selectedTab=2` = Pit Stops
+
+### Feature flags
+Flags are defined in `src/flags/index.ts` using `@vercel/flags/next` backed by `@vercel/edge-config`. Flag values are encrypted and passed to the client via `<FlagValues>`. The `getFlags()` helper in `src/app/getFlags.ts` aggregates all flag values for a page.
+
+### Caching strategy
+- `src/services/cache.ts` defines `TTL_CACHE = 86400` and the `CachedData` interface
+- Each service builds a stable Redis key (e.g. `racesResponse_session_key_${sessionKey}`) and checks Redis before fetching the API
+- `isSessionLive()` in `src/services/isSessionLive.ts` compares the session's `date_start`/`date_end` against now to decide whether to skip cache
+
+### Cloudflare/OpenNext configuration
+- `open-next.config.ts` — Cloudflare adapter wrappers and cache config
+- `wrangler.json` — Worker entry point (`.open-next/worker.js`) and static assets binding
+
+## Environment variables
+
+Required in `.env.local` (copy from `.env.example`):
+- `API_ENDPOINT` — Base URL with trailing slash
+- `UPSTASH_REDIS_REST_URL`
+- `UPSTASH_REDIS_REST_TOKEN`
+
+Optional:
+- `EDGE_CONFIG` — Vercel Edge Config connection string (needed for feature flags)
+
+See `docs/ENVIRONMENT.md` for production secrets setup.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,26 +3,75 @@
 @tailwind utilities;
 
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
+  --f1red: #e10600;
+  --f1red-dark: #b00400;
+  --carbon: #0c0c0e;
+  --carbon-light: #141418;
+  --carbon-mid: #1c1c22;
+  --carbon-border: #2a2a32;
+  --chromium: #f0f0f0;
+  --muted: #8b8b9a;
+  --gold: #ffd700;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
+html,
 body {
-  color: rgb(var(--foreground-rgb));
-  
+  background-color: var(--carbon);
+  color: var(--chromium);
+}
+
+/* Grain texture overlay */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  opacity: 0.025;
+  pointer-events: none;
+  z-index: 9998;
+}
+
+/* Top-left red atmosphere */
+body::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 600px;
+  height: 600px;
+  background: radial-gradient(
+    ellipse at 0% 0%,
+    rgba(225, 6, 0, 0.07) 0%,
+    transparent 65%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 3px;
+  height: 3px;
+}
+::-webkit-scrollbar-track {
+  background: var(--carbon);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--f1red);
 }
 
 @layer utilities {
   .text-balance {
     text-wrap: balance;
+  }
+
+  /* Left red racing stripe */
+  .stripe-left {
+    border-left: 3px solid var(--f1red);
+  }
+
+  /* Subtle top accent line */
+  .stripe-top {
+    border-top: 2px solid var(--f1red);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,23 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Barlow_Condensed, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import Image from "next/image";
 import Link from "next/link";
 import { VercelToolbar } from "@vercel/toolbar/next";
 import { currentYear } from "@/utils/constants";
 
-const inter = Inter({ subsets: ["latin"] });
+const barlow = Barlow_Condensed({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700", "800"],
+  style: ["normal", "italic"],
+  variable: "--font-barlow",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  variable: "--font-mono",
+});
 
 export const metadata: Metadata = {
   title: "F1 stats",
@@ -20,7 +31,7 @@ export default function RootLayout({
 }>) {
   const shouldInjectToolbar = process.env.NODE_ENV === "development";
   return (
-    <html lang="en">
+    <html lang="en" className={`${barlow.variable} ${jetbrainsMono.variable}`}>
       <head>
         <meta property="og:image" content="<generated>" />
         <meta property="og:image:alt" content="F1 Stats" />
@@ -30,35 +41,60 @@ export default function RootLayout({
         <meta property="og:site_name" content="F1" />
         <meta property="og:url" content="https://f1.edselserrano.com/" />
       </head>
-      <body
-        className={
-          inter.className +
-          " flex min-h-screen flex-col items-center justify-between p-4"
-        }
-      >
-        <section className="flex flex-col items-center">
-          <div>
-            <Link href={"/"}>
-              <Image
-                src="/f1logo.png"
-                alt="Logo"
-                width={300}
-                height={150}
-                priority
-              />
+      <body className="font-display flex min-h-screen flex-col bg-carbon">
+        {/* Header */}
+        <header className="relative z-10 w-full border-b border-carbon-border bg-carbon-light">
+          <div className="mx-auto max-w-7xl px-6 py-4 flex items-center justify-between">
+            <Link href="/" className="flex items-center gap-4 group">
+              <div className="relative">
+                <div className="absolute -inset-1 bg-f1red opacity-0 group-hover:opacity-10 transition-opacity duration-300 rounded" />
+                <Image
+                  src="/f1logo.png"
+                  alt="F1"
+                  width={80}
+                  height={40}
+                  priority
+                  className="object-contain"
+                />
+              </div>
             </Link>
+            <div className="flex items-center gap-3">
+              <span className="font-data text-[10px] tracking-[0.3em] uppercase text-muted">
+                Season
+              </span>
+              <span className="font-data text-sm font-bold text-f1red tracking-widest">
+                {currentYear}
+              </span>
+            </div>
           </div>
-          <span className="text-black">
-            First version of F1 stats, that you can only see the races from &nbsp;
-          {currentYear}.
-          </span>
-          
-        </section>
+          {/* Red stripe accent */}
+          <div className="h-[2px] w-full bg-gradient-to-r from-f1red via-f1red-dark to-transparent" />
+        </header>
 
-        <main className="m-5 w-full h-screen">{children}</main>
-        <footer className="fixed bottom-0  text-black">
-          <p>Powered by @pretxelcom v1.0.0</p>
+        {/* Subheading */}
+        <div className="relative z-10 border-b border-carbon-border bg-carbon px-6 py-2">
+          <div className="mx-auto max-w-7xl">
+            <p className="font-data text-[11px] text-muted tracking-widest uppercase">
+              Session data · {currentYear} Formula 1 World Championship
+            </p>
+          </div>
+        </div>
+
+        <main className="relative z-10 flex-1 mx-auto w-full max-w-7xl px-6 py-8">
+          {children}
+        </main>
+
+        <footer className="relative z-10 border-t border-carbon-border bg-carbon-light mt-16">
+          <div className="mx-auto max-w-7xl px-6 py-4 flex items-center justify-between">
+            <span className="font-data text-[10px] text-muted tracking-[0.2em] uppercase">
+              @pretxelcom
+            </span>
+            <span className="font-data text-[10px] text-muted-dark tracking-widest">
+              v1.0.0
+            </span>
+          </div>
         </footer>
+
         {shouldInjectToolbar && <VercelToolbar />}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,19 @@
 import RaceItem from "@/components/raceItem";
 import { getRaces } from "@/services/races";
 import { RaceItemType } from "@/types/RaceItemType";
-import SwitchSessionType from "@/components/switchSessionType";
 import SearchInput from "@/components/searchInput";
 import { showSummerSale } from "@/flags";
-import Skeleton from "react-loading-skeleton";
-import "react-loading-skeleton/dist/skeleton.css";
 import { Suspense } from "react";
 import { encrypt } from "@vercel/flags";
 import { FlagValues } from "@vercel/flags/react";
 import { getFlags } from "./getFlags";
 import { orderRacesLastest } from "@/utils/orderRacesByLastest";
 import TabRaces from "@/components/tabRaces";
+
 export const revalidate = 3600;
 
 async function ConfidentialFlagValues({ values }: { readonly values: any }) {
   const encryptedFlagValues = await encrypt(values);
-
   return <FlagValues values={encryptedFlagValues} />;
 }
 
@@ -33,50 +30,66 @@ const Home = async ({ searchParams }: any) => {
   );
 
   const sale = await showSummerSale();
-
   const values = await getFlags();
 
   return (
-    <section>
-      <div className="z-10 w-full p-10 items-center font-mono text-sm flex-col gap-y-10">
-        {sale && <SwitchSessionType />}
-        <Suspense fallback={null}>
-          <ConfidentialFlagValues values={values} />
-        </Suspense>
+    <>
+      <Suspense fallback={null}>
+        <ConfidentialFlagValues values={values} />
+      </Suspense>
 
-        {values.showSearchInput && <SearchInput />}
+      {values.showSearchInput && <SearchInput />}
 
+      <Suspense
+        fallback={
+          <div className="flex gap-1 mb-8">
+            {[...Array(4)].map((_, i) => (
+              <div
+                key={i}
+                className="h-8 w-24 bg-carbon-mid animate-pulse"
+              />
+            ))}
+          </div>
+        }
+      >
         <TabRaces sessionTypes={["Practice", "Qualifying", "Race"]} />
+      </Suspense>
 
-        <Suspense fallback={<Skeleton count={5} />}>
-          <ul
-            role="list"
-            className="grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8"
-          >
-            {racesOrdered?.length &&
-              racesOrdered.map((race: RaceItemType) => (
-                <li
-                  key={race.session_key}
-                  className="transition-opacity ease-in duration-700 opacity-100 overflow-hidden rounded-xl border border-gray-200"
-                >
-                  <RaceItem
-                    key={race.session_key}
-                    circuit_short_name={race.circuit_short_name}
-                    country_name={race.country_name}
-                    date_start={race.date_start}
-                    date_end={race.date_end}
-                    location={race.location}
-                    session_key={race.session_key}
-                    session_name={race.session_name}
-                    country_code={race.country_code}
-                    session_type={race.session_type}
-                  />
-                </li>
-              ))}
-          </ul>
-        </Suspense>
-      </div>
-    </section>
+      <Suspense
+        fallback={
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+            {[...Array(6)].map((_, i) => (
+              <div
+                key={i}
+                className="h-64 bg-carbon-light border-l-[3px] border-f1red animate-pulse"
+              />
+            ))}
+          </div>
+        }
+      >
+        <ul
+          role="list"
+          className="grid grid-cols-1 gap-4 lg:grid-cols-3"
+        >
+          {racesOrdered?.length > 0 &&
+            racesOrdered.map((race: RaceItemType) => (
+              <li key={race.session_key}>
+                <RaceItem
+                  circuit_short_name={race.circuit_short_name}
+                  country_name={race.country_name}
+                  date_start={race.date_start}
+                  date_end={race.date_end}
+                  location={race.location}
+                  session_key={race.session_key}
+                  session_name={race.session_name}
+                  country_code={race.country_code}
+                  session_type={race.session_type}
+                />
+              </li>
+            ))}
+        </ul>
+      </Suspense>
+    </>
   );
 };
 

--- a/src/app/session/[id]/layout.tsx
+++ b/src/app/session/[id]/layout.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import Tabs from "@/components/tabs";
-const inter = Inter({ subsets: ["latin"] });
 import { Suspense } from "react";
-import Skeleton from "react-loading-skeleton";
 
 export const metadata: Metadata = {
   title: "Session F1",
@@ -16,8 +13,12 @@ export default function SessionLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <section className={inter.className}>
-      <Suspense fallback={<Skeleton count={1} />}>
+    <section>
+      <Suspense
+        fallback={
+          <div className="h-12 bg-carbon-mid border-b border-carbon-border animate-pulse" />
+        }
+      >
         <Tabs />
       </Suspense>
       {children}

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -4,7 +4,6 @@ import PitStops from "@/components/pitstops";
 import { getRaces } from "@/services/races";
 import LiveItem from "@/components/liveItem";
 import isLiveSessionNow from "@/utils/isLiveSessionNow";
-import Skeleton from "react-loading-skeleton";
 
 interface TabJSXElement {
   [key: number]: React.JSX.Element;
@@ -30,13 +29,26 @@ export default async function Session({ params, searchParams }: any) {
 
   return (
     <section>
-      <div className="z-10 w-full items-center justify-between font-mono text-sm p-10">
-        {isLiveMode && <LiveItem isLiveFetching={true} />}
+      {isLiveMode && (
+        <div className="mb-6">
+          <LiveItem isLiveFetching={true} />
+        </div>
+      )}
 
-        <Suspense fallback={<Skeleton count={10} />}>
-          {Tabs(idSession, isLiveMode)[selectedTab]}
-        </Suspense>
-      </div>
+      <Suspense
+        fallback={
+          <div className="space-y-3">
+            {[...Array(8)].map((_, i) => (
+              <div
+                key={i}
+                className="h-12 bg-carbon-light border-l-[3px] border-carbon-border animate-pulse"
+              />
+            ))}
+          </div>
+        }
+      >
+        {Tabs(idSession, isLiveMode)[selectedTab]}
+      </Suspense>
     </section>
   );
 }

--- a/src/components/buttonItem.tsx
+++ b/src/components/buttonItem.tsx
@@ -11,10 +11,13 @@ export default function ButtonRaceItem(props: { session_key: string }) {
 
   return (
     <button
-      className="transition ease-in-out delay-150 hover:-translate-y-1 hover:scale-110 hover:bg-indigo-500 duration-300 flex-none rounded-md bg-indigo-400 px-3.5 py-2.5 text-sm font-semibold  shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 text-black"
+      className="group/btn font-data text-[10px] tracking-[0.25em] uppercase font-bold px-4 py-2.5 bg-transparent border border-carbon-border text-muted hover:border-f1red hover:text-f1red transition-all duration-200 flex items-center gap-2"
       onClick={() => goSession()}
     >
-      Details
+      View Session
+      <span className="transition-transform duration-200 group-hover/btn:translate-x-1">
+        ▶
+      </span>
     </button>
   );
 }

--- a/src/components/liveItem.tsx
+++ b/src/components/liveItem.tsx
@@ -2,6 +2,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+
 interface LiveItemProps {
   isLiveFetching?: boolean;
 }
@@ -10,6 +11,7 @@ const FETCH_INTERVAL = 5000;
 
 export default function LiveItem({ isLiveFetching }: LiveItemProps) {
   const router = useRouter();
+
   const apiCall = async (router: AppRouterInstance) => {
     console.log("FETCH LIVE DATA CLIENT-- " + new Date().getTime());
     router.refresh();
@@ -21,13 +23,16 @@ export default function LiveItem({ isLiveFetching }: LiveItemProps) {
       return () => clearInterval(id);
     }
   }, [router, isLiveFetching]);
+
   return (
-    <div className="w-full flex justify-end">
-      <span className="relative top-0 right-0 flex h-4 w-4">
-        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
-        <span className="relative inline-flex rounded-full h-4 w-4 bg-red-500"></span>
+    <div className="flex items-center gap-1.5">
+      <span className="relative flex h-2 w-2 flex-none">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-f1red opacity-75" />
+        <span className="relative inline-flex rounded-full h-2 w-2 bg-f1red" />
       </span>
-      <span className="text-xs pl-2 text-black">Live</span>
+      <span className="font-data text-[10px] font-bold tracking-[0.25em] uppercase text-f1red">
+        LIVE
+      </span>
     </div>
   );
 }

--- a/src/components/pitstopItem.tsx
+++ b/src/components/pitstopItem.tsx
@@ -5,39 +5,35 @@ import Image from "next/image";
 
 export default function PitstopItem({ person }: any) {
   const ref: Ref<HTMLLIElement> = useRef(null);
-  const isVisible1 = useIsVisible(ref);
+  const isVisible = useIsVisible(ref);
+
   return (
     <li
       key={person.key}
       ref={ref}
-      className={`transition-opacity ease-in duration-700 flex gap-x-4 py-5 ${
-        isVisible1 ? "opacity-100" : "opacity-0"
+      className={`transition-all duration-700 ease-out flex items-center gap-5 py-4 border-b border-carbon-border last:border-b-0 ${
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"
       }`}
     >
-      {person.imageUrl && (
-        <Image
-          className="h-12 w-12 flex-none rounded-full bg-gray-50"
-          src={person.imageUrl ?? ""}
-          width={48}
-          height={48}
-          alt={person.name}
-        />
-      )}
-
-      {!person.imageUrl && (
-        <div>
-          <span
-            className={
-              "bg-gray-400 h-12 w-12 rounded-full flex items-center justify-center ring-8 ring-white"
-            }
-          >
+      {/* Driver avatar */}
+      <div className="flex-none">
+        {person.imageUrl ? (
+          <Image
+            className="h-10 w-10 object-cover bg-carbon-mid"
+            src={person.imageUrl}
+            width={40}
+            height={40}
+            alt={person.name}
+          />
+        ) : (
+          <div className="h-10 w-10 bg-carbon-mid border border-carbon-border flex items-center justify-center">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
               strokeWidth="1.5"
               stroke="currentColor"
-              className="h-7 w-7 text-white"
+              className="h-5 w-5 text-muted"
               aria-hidden="true"
             >
               <path
@@ -46,19 +42,27 @@ export default function PitstopItem({ person }: any) {
                 d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
               />
             </svg>
-          </span>
-        </div>
-      )}
+          </div>
+        )}
+      </div>
 
-      <div>
-        <p className="text-sm font-semibold leading-6 text-gray-900">
+      {/* Name + pitstop count */}
+      <div className="flex-1 min-w-0">
+        <p className="font-display font-bold italic text-base uppercase tracking-wide text-chromium truncate">
           {person.name}
         </p>
-        <p className="mt-1 truncate text-xs leading-5 text-gray-500">
-          Pitstops: {person.pitstops}
+        <p className="font-data text-[10px] text-muted tracking-widest uppercase mt-0.5">
+          {person.pitstops} {person.pitstops === 1 ? "stop" : "stops"}
         </p>
-        <p className="mt-1 truncate text-xs leading-5 text-gray-500">
-          Total: {person.total_duration} Seconds
+      </div>
+
+      {/* Total time */}
+      <div className="flex-none text-right">
+        <p className="font-data text-lg font-bold text-chromium tabular-nums">
+          {person.total_duration}
+        </p>
+        <p className="font-data text-[10px] text-muted tracking-widest uppercase">
+          sec total
         </p>
       </div>
     </li>

--- a/src/components/pitstops.tsx
+++ b/src/components/pitstops.tsx
@@ -1,6 +1,7 @@
 import { getPitstops } from "@/services/pitstops";
 import ListPitstop from "./listPitstop";
 import adaptPitstops from "@/utils/adaptPitstops";
+
 export type PitStopProps = {
   session_key: string;
   liveMode: boolean;
@@ -11,7 +12,15 @@ export default async function PitStops(props: PitStopProps) {
   const people = adaptPitstops(pitstops);
 
   return (
-    <div className="flow-root pt-10">
+    <div className="max-w-2xl">
+      <div className="mb-6 flex items-center gap-3">
+        <span className="font-data text-[10px] tracking-[0.3em] uppercase text-muted">
+          Drivers
+        </span>
+        <span className="font-data text-[10px] text-muted-dark">
+          {people.length}
+        </span>
+      </div>
       <ListPitstop people={people} />
     </div>
   );

--- a/src/components/raceControl.tsx
+++ b/src/components/raceControl.tsx
@@ -16,11 +16,19 @@ const timeLineAdaptedRequest = async (sessionKey: string) => {
 };
 
 export default async function RaceControl(props: RaceControlProp) {
-  let timeLineAdapted = await timeLineAdaptedRequest(props.session_key);
+  const timeLineAdapted = await timeLineAdaptedRequest(props.session_key);
 
   return (
-    <div className="flow-root pt-10">
-      <ul role="list" className="-mb-8">
+    <div className="max-w-2xl">
+      <div className="mb-6 flex items-center gap-3">
+        <span className="font-data text-[10px] tracking-[0.3em] uppercase text-muted">
+          Events
+        </span>
+        <span className="font-data text-[10px] text-muted-dark">
+          {timeLineAdapted.length}
+        </span>
+      </div>
+      <ul role="list">
         {timeLineAdapted.map((event, eventIdx) => (
           <RaceControlItem
             key={event.id}

--- a/src/components/raceControlItem.tsx
+++ b/src/components/raceControlItem.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { Ref, useRef } from "react";
-import { classNames } from "@/utils/classNames";
 import { useIsVisible } from "@/hooks/useIsVisible";
 
 export default function RaceControlItem({
@@ -9,54 +8,44 @@ export default function RaceControlItem({
   timeLineAdapted,
 }: any) {
   const ref: Ref<HTMLLIElement> = useRef(null);
-  const isVisible1 = useIsVisible(ref);
+  const isVisible = useIsVisible(ref);
+  const isLast = eventIdx === timeLineAdapted.length - 1;
+
   return (
     <li
       ref={ref}
-      key={event.id}
-      className={`transition-opacity ease-in duration-700 ${
-        isVisible1 ? "opacity-100" : "opacity-0"
+      className={`transition-all duration-700 ease-out ${
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"
       }`}
     >
-      <div className="relative pb-8">
-        {eventIdx !== timeLineAdapted.length - 1 ? (
+      <div className="relative pb-6">
+        {/* Vertical connector line */}
+        {!isLast && (
           <span
-            className="absolute left-4 top-4 -ml-px h-full w-0.5 bg-gray-200"
+            className="absolute left-[9px] top-5 bottom-0 w-px bg-carbon-border"
             aria-hidden="true"
           />
-        ) : null}
-        <div className="relative flex space-x-3">
-          <div>
-            <span
-              className={classNames(
-                event.iconBackground,
-                "h-8 w-8 rounded-full flex items-center justify-center ring-8 ring-white"
-              )}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth="1.5"
-                stroke="currentColor"
-                className="h-5 w-5 text-white"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
-                />
-              </svg>
+        )}
+
+        <div className="relative flex gap-4">
+          {/* Dot indicator */}
+          <div className="flex-none mt-1">
+            <span className="flex h-[18px] w-[18px] items-center justify-center bg-carbon-mid border border-carbon-border">
+              <span className="h-1.5 w-1.5 rounded-full bg-f1red" />
             </span>
           </div>
-          <div className="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
-            <div>
-              <p className="text-sm text-gray-500">{event.content}</p>
-            </div>
-            <div className="whitespace-nowrap text-right text-sm text-gray-500">
-              <time dateTime={event.datetime.toString()}>{event.date}</time>
-            </div>
+
+          {/* Content */}
+          <div className="flex min-w-0 flex-1 items-start justify-between gap-4 pt-0.5">
+            <p className="font-data text-xs text-chromium leading-relaxed">
+              {event.content}
+            </p>
+            <time
+              dateTime={event.datetime?.toString()}
+              className="font-data text-[10px] text-muted tracking-wide whitespace-nowrap flex-none"
+            >
+              {event.date}
+            </time>
           </div>
         </div>
       </div>

--- a/src/components/raceItem.tsx
+++ b/src/components/raceItem.tsx
@@ -9,75 +9,119 @@ import LiveItem from "./liveItem";
 import ButtonRaceItem from "./buttonItem";
 import isLiveSessionNow from "@/utils/isLiveSessionNow";
 
+const SESSION_TYPE_LABELS: Record<string, string> = {
+  Race: "RACE",
+  Qualifying: "QUALI",
+  Practice: "FP",
+  Sprint: "SPR",
+};
+
 export default async function RaceItem(props: RaceItemType) {
   const urlImage = findFlagUrlByIso3Code(props.country_code);
-
   const winner = await getWinnerByRace(props.session_key);
+  const isLive = isLiveSessionNow(
+    new Date(props.date_start),
+    new Date(props.date_end)
+  );
+
+  const sessionLabel =
+    SESSION_TYPE_LABELS[props.session_name] ?? props.session_name.toUpperCase();
 
   return (
-    <>
-      <div className="flex items-center gap-x-4 border-b border-gray-900/5 bg-gray-50 p-6">
-        <Image
-          src={urlImage !== "" ? urlImage : "/European_version.png"}
-          alt={props.circuit_short_name}
-          width={50}
-          height={32}
-          className="h-12 w-12 flex-none rounded-lg bg-white object-cover ring-1 ring-gray-900/10"
-        />
-        <div className="text-sm font-medium leading-6 text-gray-900">
-          {props.circuit_short_name}
-        </div>
-
-        <div className="w-full flex justify-end">
-          <div className=" text-black p-4">{props.session_name}</div>
-        </div>
-
-        {isLiveSessionNow(
-          new Date(props.date_start),
-          new Date(props.date_end)
-        ) && <LiveItem />}
-      </div>
-      <dl className="-my-3 divide-y divide-gray-100 px-6 py-4 text-sm leading-6">
-        <div className="flex justify-between gap-x-4 py-3">
-          <dt className="text-gray-500">Start Race</dt>
-          <dd className="text-gray-700">
-            <time dateTime={props.date_start.toString()}>
-              {dayjs(props.date_start).format("LLLL")}
-            </time>
-          </dd>
-        </div>
-        <div className="flex justify-between gap-x-4 py-3">
-          <dt className="text-gray-500">End Race</dt>
-          <dd className="text-gray-700">
-            <time dateTime={props.date_end.toString()}>
-              {dayjs(props.date_end).format("LLLL")}
-            </time>
-          </dd>
-        </div>
-        <div className="flex justify-between gap-x-4 py-3">
-          <dt className="text-gray-500">Country</dt>
-          <dd className="flex items-start gap-x-2">
-            <div className="font-medium text-gray-900">
+    <article className="group relative bg-carbon-light stripe-left hover:border-l-f1red-dark transition-all duration-300 overflow-hidden">
+      {/* Top header row */}
+      <div className="flex items-start justify-between gap-3 p-5 pb-4 border-b border-carbon-border">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex-none">
+            <Image
+              src={urlImage !== "" ? urlImage : "/European_version.png"}
+              alt={props.country_name}
+              width={44}
+              height={29}
+              className="object-cover w-[44px] h-[29px]"
+              style={{ imageRendering: "crisp-edges" }}
+            />
+          </div>
+          <div className="min-w-0">
+            <h3 className="font-display font-extrabold text-xl italic uppercase tracking-wide text-chromium leading-tight truncate group-hover:text-white transition-colors">
+              {props.circuit_short_name}
+            </h3>
+            <p className="font-data text-[10px] text-muted tracking-widest uppercase mt-0.5">
               {props.country_name}
-            </div>
-          </dd>
+            </p>
+          </div>
         </div>
-        <div className="flex justify-between gap-x-4 py-3">
-          <dt className="text-gray-500">Winner</dt>
-          <dd className="flex items-start gap-x-2">
-            <div className="font-medium text-gray-900">
-              {!winner?.driver ? "No winner yet" : winner.driver.full_name}
-            </div>
-          </dd>
+
+        <div className="flex flex-col items-end gap-2 flex-none">
+          <span className="font-data text-[10px] font-bold tracking-[0.2em] text-carbon bg-f1red px-2 py-0.5 uppercase">
+            {sessionLabel}
+          </span>
+          {isLive && <LiveItem />}
         </div>
-        <div className="flex justify-between gap-x-4 py-3">
-          <dd className="flex items-start gap-x-2">
-            <div className="font-medium text-gray-900">
-              <ButtonRaceItem session_key={props.session_key} />
-            </div>
-          </dd>
+      </div>
+
+      {/* Data grid */}
+      <div className="px-5 py-4 space-y-0 divide-y divide-carbon-border">
+        <DataRow
+          label="START"
+          value={dayjs(props.date_start).format("D MMM · HH:mm")}
+          mono
+        />
+        <DataRow
+          label="END"
+          value={dayjs(props.date_end).format("D MMM · HH:mm")}
+          mono
+        />
+        <DataRow
+          label="LOCATION"
+          value={props.location ?? props.country_name}
+        />
+        <div className="flex items-center justify-between py-3">
+          <span className="font-data text-[10px] tracking-[0.25em] uppercase text-muted">
+            WINNER
+          </span>
+          {winner?.driver ? (
+            <span className="font-display font-bold italic text-base uppercase text-gold tracking-wide">
+              {winner.driver.full_name}
+            </span>
+          ) : (
+            <span className="font-data text-xs text-muted-dark">—</span>
+          )}
         </div>
-      </dl>
-    </>
+      </div>
+
+      {/* Footer */}
+      <div className="px-5 pb-5 flex justify-end">
+        <ButtonRaceItem session_key={props.session_key} />
+      </div>
+
+      {/* Hover shimmer */}
+      <div className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-white/[0.02] to-transparent" />
+    </article>
+  );
+}
+
+function DataRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between py-2.5 gap-4">
+      <span className="font-data text-[10px] tracking-[0.25em] uppercase text-muted flex-none">
+        {label}
+      </span>
+      <span
+        className={`text-xs text-chromium text-right ${
+          mono ? "font-data" : "font-display font-semibold uppercase tracking-wide"
+        }`}
+      >
+        {value}
+      </span>
+    </div>
   );
 }

--- a/src/components/searchInput.tsx
+++ b/src/components/searchInput.tsx
@@ -1,19 +1,19 @@
 export default function SearchInput() {
   return (
-    <section className="relative w-full max-w-xl mx-auto bg-white rounded-full mb-4">
+    <div className="relative w-full max-w-xl mb-6">
       <input
-        placeholder="race"
-        className="rounded-lg  border-stroke w-full h-14 bg-transparent py-2 pl-8 pr-32 outline-none border-2 border-gray-100 shadow-md hover:outline-none focus:ring-indigo-200 focus:border-indigo-200"
+        placeholder="Search races..."
+        className="w-full h-11 bg-carbon-light border border-carbon-border text-chromium font-data text-xs tracking-wide pl-4 pr-28 outline-none placeholder:text-muted focus:border-f1red transition-colors duration-200"
         type="text"
         name="query"
         id="query"
       />
       <button
         type="submit"
-        className="absolute inline-flex items-center h-8 px-4 py-2 text-sm text-white transition duration-150 ease-in-out rounded-full outline-none right-3 top-3 bg-indigo-400 sm:px-6 sm:text-base sm:font-medium hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500"
+        className="absolute right-0 top-0 h-11 px-5 font-data text-[10px] font-bold tracking-[0.25em] uppercase text-white bg-f1red hover:bg-f1red-dark transition-colors duration-200 flex items-center gap-2"
       >
         <svg
-          className="-ml-0.5 sm:-ml-1 mr-2 w-4 h-4 sm:h-5 sm:w-5"
+          className="w-3.5 h-3.5"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -24,10 +24,10 @@ export default function SearchInput() {
             strokeLinejoin="round"
             strokeWidth="2"
             d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-          ></path>
+          />
         </svg>
         Search
       </button>
-    </section>
+    </div>
   );
 }

--- a/src/components/tabRaces.tsx
+++ b/src/components/tabRaces.tsx
@@ -10,15 +10,26 @@ export default function TabRaces(props: TabRacesProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const activeSessionType = searchParams.get("sessionType");
+
   return (
-    <div className="relative  mx-auto gap-1 rounded-lg border border-stroke bg-white p-1 dark:border-dark-stroke dark:bg-white/[.02] mb-4 text-center w-full max-w-xl">
+    <div className="flex items-center gap-1 mb-8">
+      <button
+        className={`font-data text-[10px] tracking-[0.25em] uppercase px-4 py-2 transition-all duration-200 border ${
+          !activeSessionType
+            ? "bg-f1red border-f1red text-white"
+            : "border-carbon-border text-muted hover:border-muted hover:text-chromium bg-transparent"
+        }`}
+        onClick={() => router.push("/")}
+      >
+        ALL
+      </button>
       {props.sessionTypes.map((sessionType, index) => (
         <button
           key={index}
-          className={`inline-flex h-8 items-center justify-center rounded-md px-3 text-sm font-medium duration-200 dark:text-black ${
+          className={`font-data text-[10px] tracking-[0.25em] uppercase px-4 py-2 transition-all duration-200 border ${
             activeSessionType === sessionType
-              ? "bg-black text-white"
-              : "text-dark-5 hover:bg-black hover:text-white"
+              ? "bg-f1red border-f1red text-white"
+              : "border-carbon-border text-muted hover:border-muted hover:text-chromium bg-transparent"
           }`}
           onClick={() => router.push("?sessionType=" + sessionType)}
         >

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -1,60 +1,63 @@
 "use client";
-import { classNames } from "@/utils/classNames";
-import { useRouter } from "next/navigation";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
 const tabs = [
-  { name: "Race Control", href: "#" },
-  { name: "Pit stops", href: "#" },
+  { name: "Race Control", label: "RACE CONTROL" },
+  { name: "Pit stops", label: "PIT STOPS" },
 ];
 
 export default function Tabs() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const selectedTab = parseInt(searchParams.get("selectedTab") || "1");
+
   return (
-    <div>
+    <div className="mb-8">
+      {/* Mobile select */}
       <div className="sm:hidden">
         <label htmlFor="tabs" className="sr-only">
           Select a tab
         </label>
-
         <select
           id="tabs"
           name="tabs"
-          className="block w-full rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500"
-          defaultValue={tabs[selectedTab - 1].name}
-          test-id={selectedTab}
+          className="block w-full bg-carbon-light border border-carbon-border text-chromium font-data text-xs tracking-widest py-2 px-3 focus:border-f1red focus:outline-none"
+          defaultValue={selectedTab}
           onChange={(e) => router.push("?selectedTab=" + e.target.value)}
         >
           {tabs.map((tab, tabIdx) => (
             <option key={tab.name} value={tabIdx + 1}>
-              {tab.name}
+              {tab.label}
             </option>
           ))}
         </select>
       </div>
-      <div className="hidden sm:block">
-        <div className="border-b border-gray-200">
-          <nav className="-mb-px flex" aria-label="Tabs">
-            {tabs.map((tab, tabIdx) => (
+
+      {/* Desktop tabs */}
+      <div className="hidden sm:block border-b border-carbon-border">
+        <nav className="flex" aria-label="Tabs">
+          {tabs.map((tab, tabIdx) => {
+            const isActive = selectedTab === tabIdx + 1;
+            return (
               <Link
                 key={tab.name}
                 href={`?selectedTab=${tabIdx + 1}`}
-                className={classNames(
-                  selectedTab === tabIdx + 1
-                    ? "border-indigo-500 text-indigo-600"
-                    : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700",
-                  "w-1/4 border-b-2 py-4 px-1 text-center text-sm font-medium"
-                )}
-                aria-current={selectedTab === tabIdx + 1 ? "page" : undefined}
+                className={`relative font-data text-[11px] tracking-[0.25em] uppercase px-6 py-4 transition-colors duration-200 ${
+                  isActive
+                    ? "text-chromium"
+                    : "text-muted hover:text-chromium"
+                }`}
+                aria-current={isActive ? "page" : undefined}
               >
-                {tab.name}
+                {tab.label}
+                {isActive && (
+                  <span className="absolute bottom-0 left-0 right-0 h-[2px] bg-f1red" />
+                )}
               </Link>
-            ))}
-          </nav>
-        </div>
+            );
+          })}
+        </nav>
       </div>
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,38 @@ const config: Config = {
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        f1red: "#E10600",
+        "f1red-dark": "#B00400",
+        carbon: "#0C0C0E",
+        "carbon-light": "#141418",
+        "carbon-mid": "#1C1C22",
+        "carbon-border": "#2A2A32",
+        chromium: "#F0F0F0",
+        muted: "#8B8B9A",
+        "muted-dark": "#55555F",
+        gold: "#FFD700",
+      },
+      fontFamily: {
+        display: ["var(--font-barlow)", "sans-serif"],
+        data: ["var(--font-mono)", "monospace"],
+      },
+      keyframes: {
+        "slide-up": {
+          "0%": { opacity: "0", transform: "translateY(10px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+        "fade-in": {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
+      },
+      animation: {
+        "slide-up": "slide-up 0.5s ease-out forwards",
+        "fade-in": "fade-in 0.4s ease-out forwards",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary

- **Dark carbon theme** — replaces generic light/gray with `#0C0C0E` carbon base, `#E10600` F1 red accents, and `#FFD700` gold for winner highlights
- **Typography overhaul** — `Barlow Condensed` (italic, bold, uppercase) for display text + `JetBrains Mono` for timing data, creating a genuine telemetry-screen feel
- **Race cards** redesigned as timing-tower readouts: left red stripe, sharp edges, monospaced data grid, winner highlighted in gold
- **All components restyled**: session filter tabs, detail tabs, race control timeline, pit stop list, live indicator, search input, and CTA button
- **Atmosphere**: grain texture overlay, top-left red radial glow, custom red scrollbar, hover shimmer on cards

## Test plan

- [ ] Home page renders race cards in dark theme with red left stripe
- [ ] Session type filter tabs (ALL / Practice / Qualifying / Race) toggle correctly
- [ ] Race card shows country flag, circuit name, session badge, winner in gold
- [ ] LIVE indicator pulses red and auto-refreshes when a session is active
- [ ] Session detail page shows Race Control timeline and Pit Stops tab with new styles
- [ ] Fonts load correctly (Barlow Condensed for headers, JetBrains Mono for data)
- [ ] No regressions in TypeScript (pre-existing test type errors are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)