### PR TITLE
test: add comprehensive unit tests, fix jest config, and IMPROVEMENTS.md

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,388 @@
+# Improvements & New Features
+
+This document captures concrete, actionable improvement ideas grounded in the current codebase architecture. All ideas reference actual files, services, and data fields available today.
+
+---
+
+## High Priority (Quick Wins)
+
+These use existing data and infrastructure with minimal net-new work.
+
+### 1. Individual Pit Stop Timeline per Driver
+
+**Description:** The current `pitstops.tsx` + `adaptPitstops.ts` aggregates all stops into a single total duration per driver. Expand the pit stop view to show each individual stop for a driver — lap number, stop number, and duration — in a drill-down panel or expandable row.
+
+**User Value:** Users can see exactly when and how long each stop was, enabling strategic analysis (e.g., undercut windows, slow stops).
+
+**Technical Approach:**
+- The raw `pit` API already returns individual stop records with `lap`, `pit_duration`, and `driver_number`. The `adaptPitstops.ts` util currently discards per-lap detail.
+- Add a `PitstopDetailItem` client component with an expand/collapse toggle (Headless UI `Disclosure` is already installed via `@headlessui/react`).
+- No new API calls needed — data is already fetched in `getPitstops()`.
+
+**Estimated Complexity:** Low (1–2 days)
+
+---
+
+### 2. Race Control Event Categorization & Filtering
+
+**Description:** The `race_control` API returns a `category` field on every event (see `RaceControlItem.ts`), but `adaptRaceControlToTimeline.ts` drops it entirely. Surface this field and let users filter the timeline by category (e.g., SafetyCar, Flag, DRS).
+
+**User Value:** During a long race, users can zero in on safety car periods or flag events without scrolling through hundreds of messages.
+
+**Technical Approach:**
+- Update `adaptRaceControlToTimeline.ts` to carry the `category` field through to the adapted shape.
+- Add a `CategoryFilter` client component (similar to `TabRaces`) above the timeline in `raceControl.tsx`. Use `useSearchParams` to persist the active filter.
+- Color-code the dot indicator in `RaceControlItem.tsx` by category — already has an `iconBackground` stub that's set to a hardcoded `bg-gray-400`.
+
+**Estimated Complexity:** Low (1 day)
+
+---
+
+### 3. Dynamic Session Metadata & Styled OG Images
+
+**Description:** The session layout uses a static title `"Session F1"` (`src/app/session/[id]/layout.tsx`) and the OG image (`opengraph-image.tsx`) renders a plain white background with plain text. Both should reflect the actual circuit name, country, and session type.
+
+**User Value:** Sharing a session link on social media shows meaningful, on-brand preview cards rather than a blank placeholder.
+
+**Technical Approach:**
+- Move `generateMetadata` into the session page and fetch session data (already done in `page.tsx` via `getRaces`) to populate `title` and `description` dynamically.
+- Update `opengraph-image.tsx` to apply the carbon dark theme (using inline styles with `var(--carbon)` equivalent hex values since OG renders in a sandboxed edge environment) and include circuit name, country flag, and session type label.
+
+**Estimated Complexity:** Low (half a day)
+
+---
+
+### 4. Fastest Pit Stop Highlight
+
+**Description:** In the pit stops tab, visually highlight the single fastest individual stop across the session, surfacing it as a stat above the driver list.
+
+**User Value:** Instantly answers the "who had the fastest stop?" question — a key talking point for any race.
+
+**Technical Approach:**
+- In `getPitstops()` the raw records include `pit_duration` per stop. After enrichment, find the min.
+- Add a `FastestStop` server component rendered above `<ListPitstop>` in `pitstops.tsx`, displaying driver name, stop number, lap, and duration in the gold (`--gold: #ffd700`) accent colour already defined in `globals.css`.
+
+**Estimated Complexity:** Low (half a day)
+
+---
+
+### 5. Functional Search / Filter on Sessions List
+
+**Description:** `SearchInput` exists as a component (`src/components/searchInput.tsx`) and is gated behind the `showSearchInput` feature flag in `getFlags.ts`, but the input has no `onChange` handler — it renders a non-functional UI shell.
+
+**User Value:** Lets users quickly find a circuit or country without scrolling the grid.
+
+**Technical Approach:**
+- Make `SearchInput` a proper controlled client component using `useSearchParams` + `useRouter`, filtering the sessions grid by `circuit_short_name` or `country_name` client-side (data is already loaded).
+- Alternatively, pass a `?q=` query param to the server page for server-side filtering.
+- Enable the flag in Edge Config to roll it out.
+
+**Estimated Complexity:** Low (1 day)
+
+---
+
+### 6. Sorted Pit Stops (Fastest to Slowest Total)
+
+**Description:** The driver list in the pit stop tab (`listPitstop.tsx`) currently reflects the order drivers appear in the API response. Sort drivers by total pit time ascending so the most efficient team is at the top, like a leaderboard.
+
+**User Value:** Turns the pit stop list from a data dump into an immediately readable ranking.
+
+**Technical Approach:**
+- Add a `.sort((a, b) => a.total_duration - b.total_duration)` step at the end of `adaptPitstops.ts`.
+- Optionally add a rank number badge to `PitstopItem.tsx`, styled with the existing `font-data` monospace class.
+
+**Estimated Complexity:** Very Low (< 1 hour)
+
+---
+
+### 7. Session Year Selector
+
+**Description:** The app hardcodes `currentYear` from `src/utils/constants.ts` (`new Date().getFullYear()`). There is no way to browse historical seasons.
+
+**User Value:** Fans want to compare 2024 vs 2025 data, review past championship-deciding races, etc.
+
+**Technical Approach:**
+- Add a `?year=` search param to the home page alongside `?sessionType=`.
+- Pass `year` through to `getRaces()` in `races.ts` (the `QUERIES` string already builds `?year=${currentYear}` — swap the constant for the param).
+- Add a year picker component beside `TabRaces` in `page.tsx`.
+- Cache keys in all services are keyed by year already (e.g., `racesResponse_year_${currentYear}`), so cache isolation is automatic.
+
+**Estimated Complexity:** Low–Medium (1–2 days)
+
+---
+
+## Medium Priority (New Capabilities)
+
+Features that require new service functions or moderate front-end work.
+
+### 8. Full Session Standings / Position Tab
+
+**Description:** The `position` API endpoint already exists and is used in `winnerByRace.ts` (querying `position<=1`). Expand it to fetch all positions for a session and display a full finishing order table.
+
+**User Value:** The #1 most requested view for any race — the race result.
+
+**Technical Approach:**
+- Add a new `getPositionsBySession(sessionKey)` service in `src/services/positions.ts`, fetching `position?session_key=${sessionKey}` and grouping by `driver_number`, taking the last recorded position for each driver.
+- Add a third tab "Results" to the `tabs` array in `tabs.tsx`.
+- Create a `Results` server component and a `DriverPositionItem` client component with position badge, driver number, name, and team colour if available.
+- Cache with the same Redis + live-bypass pattern used in `raceControl.ts`.
+
+**Estimated Complexity:** Medium (2–3 days)
+
+---
+
+### 9. Driver Profile Page
+
+**Description:** Driver data is fetched frequently (`getDriver` is called per driver in `pitstops.ts` and `winnerByRace.ts`) but only used inline. Build a `/driver/[number]` route that shows a driver's profile: name, team, country, headshot, and their pit stop history across the current season.
+
+**User Value:** Adds depth — users can explore their favourite driver's performance across all sessions.
+
+**Technical Approach:**
+- The `drivers` API supports `?driver_number=` already, returning `full_name`, `headshot_url`, `team_name`, `team_colour`, `country_code`, `name_acronym`.
+- Create `src/app/driver/[number]/page.tsx` as a Server Component. Fetch the driver from `getDriver(number)` and all sessions from `getRaces({})`, then cross-reference pit stop data to show recent sessions participated in.
+- Link to driver profiles from `PitstopItem.tsx` and the winner row in `RaceItem.tsx`.
+
+**Estimated Complexity:** Medium (2–3 days)
+
+---
+
+### 10. Race-to-Race Pit Stop Comparison Chart
+
+**Description:** A bar or line chart comparing total pit stop time across all races in the season, for all drivers or a selected driver.
+
+**User Value:** Shows how pit strategy performance evolved over the season — a compelling data viz for fans and analysts.
+
+**Technical Approach:**
+- No new API endpoints needed. Call `getPitstops()` for each session key from `getRaces()`.
+- Add a charting library (e.g., `recharts` or `chart.js`) — currently none installed.
+- Render a client component at `/driver/[number]?chart=pitstops` or as a new `/season/stats` page.
+- Be mindful of rate limiter (3 req/s, 30 req/min) in `rateLimiter.ts` when batch-fetching across many sessions — use `Promise.all` with concurrency control.
+
+**Estimated Complexity:** Medium–High (3–4 days)
+
+---
+
+### 11. "Next Race" Countdown Widget
+
+**Description:** Display a countdown timer to the next scheduled session on the home page, derived from upcoming sessions already returned by the `sessions` API.
+
+**User Value:** Keeps fans engaged between races — the home page becomes a regular destination, not just a post-race data dump.
+
+**Technical Approach:**
+- `getRaces()` returns `date_start` for all sessions. Filter for sessions in the future and sort ascending to find the next one.
+- Create a `NextRace` client component that calculates remaining time client-side using `useEffect` and `dayjs` (already installed).
+- Render it in `page.tsx` above the tab filters as a persistent banner.
+
+**Estimated Complexity:** Low–Medium (1–2 days)
+
+---
+
+### 12. Live Session Position Tracker (Real-Time Leaderboard)
+
+**Description:** For live sessions, show a live timing tower with current positions updating every 5 seconds. This is the motorsport equivalent of a live scoreboard.
+
+**User Value:** The killer feature for live race viewing — turning this into a companion app during race weekends.
+
+**Technical Approach:**
+- The `position` API can be polled for live data (the live bypass is already implemented in `isSessionLive.ts`).
+- The existing `LiveItem` component already polls via `router.refresh()` every `FETCH_INTERVAL = 5000ms`. Extend this pattern with a new `LiveLeaderboard` client component.
+- Add a "Leaderboard" tab (tab index 3) in `tabs.tsx`, only rendered when `isLiveMode` is true in `page.tsx`.
+- Position changes (up/down vs previous poll) can be tracked in local component state.
+
+**Estimated Complexity:** Medium (2–3 days)
+
+---
+
+### 13. Team-Grouped Pit Stops View
+
+**Description:** The driver API returns `team_name` and `team_colour` fields. Group pit stop results by constructor and show total stops and cumulative time per team.
+
+**User Value:** Answers "which team had the best pit wall performance?" — a key strategic dimension.
+
+**Technical Approach:**
+- Update `adaptPitstops.ts` (or add a sibling `adaptPitstopsByTeam.ts`) to group by `team_name` from the enriched driver data.
+- Add a toggle in `pitstops.tsx` (Drivers / Teams) using a `useSearchParams` approach, matching the existing `TabRaces` pattern.
+
+**Estimated Complexity:** Medium (1–2 days)
+
+---
+
+## Low Priority / Future Vision
+
+Ambitious ideas requiring new data sources or significant engineering.
+
+### 14. Multi-Year Historical Comparison Page
+
+**Description:** A dedicated `/compare` route where users can overlay the same circuit across different years — pit stops, race control events, race results.
+
+**User Value:** Deep statistical analysis for fans and motorsport journalists.
+
+**Technical Approach:**
+- Requires fetching `sessions?year=X&circuit=Y` for multiple years. The API supports `year=` already; add `circuit_short_name` filtering or filter client-side.
+- Build a comparison layout with two data columns, one per year, using the existing card/timeline components.
+- Complexity grows with the number of years supported.
+
+**Estimated Complexity:** High (1–2 weeks)
+
+---
+
+### 15. Push Notifications for Live Sessions
+
+**Description:** Allow users to subscribe to push notifications when a tracked session goes live.
+
+**User Value:** Race fans don't have to remember to check — they get notified at session start.
+
+**Technical Approach:**
+- Requires a Web Push implementation (service worker, VAPID keys) and a Vercel Cron Job to check `isSessionLive()` periodically and dispatch notifications.
+- Vercel KV (or Upstash Redis already in use) can store subscription endpoints.
+- This is a significant infrastructure addition outside the current scope.
+
+**Estimated Complexity:** Very High (1–2 weeks)
+
+---
+
+### 16. Telemetry Visualisation (Speed / Throttle / Brake)
+
+**Description:** If the data API exposes car data (speed, throttle, brake, gear), build a lap telemetry chart for a selected driver.
+
+**User Value:** The gold standard of F1 data apps — used by every serious fan and pundit.
+
+**Technical Approach:**
+- OpenF1 exposes a `car_data` endpoint with `speed`, `throttle`, `brake`, `drs`, and `n_gear` fields per driver per sample.
+- Add a `getCarData(sessionKey, driverNumber, lap)` service following the same Redis cache + rate-limiter pattern.
+- Render using a line chart (recharts or similar). The data volume is large so sampling or lazy-loading per lap is necessary.
+
+**Estimated Complexity:** Very High (2–3 weeks)
+
+---
+
+### 17. Weather During Session
+
+**Description:** Overlay session weather data (air/track temperature, humidity, rainfall flag) alongside race control events on the timeline.
+
+**User Value:** Context for interpreting strategy decisions — a rain flag event hits differently when you can see the conditions that caused it.
+
+**Technical Approach:**
+- OpenF1 exposes a `weather` endpoint per `session_key`.
+- Add a `getWeatherBySession(sessionKey)` service and merge weather snapshots into the race control timeline using matching timestamps.
+- Render weather badges in `RaceControlItem.tsx` at matching time intervals.
+
+**Estimated Complexity:** Medium–High (3–5 days)
+
+---
+
+### 18. Embedded Social / Commentary Feed
+
+**Description:** A curated real-time commentary panel (e.g., via a public feed or user-submitted reactions) alongside the race control timeline.
+
+**User Value:** Community watch-along experience — F1 fans are intensely social during races.
+
+**Technical Approach:**
+- Would require an external service (e.g., Supabase Realtime, Pusher, or a new API route with Server-Sent Events) and authentication.
+- Far outside the current stateless RSC + Redis architecture; significant scope increase.
+
+**Estimated Complexity:** Very High (3–4 weeks)
+
+---
+
+## Performance & Technical Improvements
+
+### 19. Per-Item Redis Key Strategy for Race Control
+
+**Description:** `getRaceControlBySession` caches the entire race control array under one Redis key. A session with hundreds of events stores and retrieves a large blob. For live sessions, this is re-fetched every 5 seconds from the API with zero caching.
+
+**File:** `src/services/raceControl.ts`
+
+**Fix:** For live sessions, implement an append-only cache strategy — store event count and only fetch events newer than the latest cached timestamp using a `date>` query param if the API supports it. For non-live sessions, the current approach is fine.
+
+---
+
+### 20. Sequential Driver Fetches in getPitstops
+
+**Description:** `getPitstops` in `src/services/pitstops.ts` fetches each unique driver with a `for...of` loop (sequential `await`). With 20 drivers, this can add hundreds of milliseconds of serial latency.
+
+**Fix:** Replace with `Promise.all(uniqueDriverNumbers.map(n => getDriver(n)))` to fetch all drivers in parallel. The rate limiter in `rateLimiter.ts` already handles burst limiting so this is safe to do.
+
+---
+
+### 21. Type-Safe API Response Shapes
+
+**Description:** Service functions return `any` throughout — `pitstops.ts` uses `PitstopData` with `[key: string]: any`, `driver.ts` returns untyped data, and `adaptPitstops.ts` accepts `any[]`. The `RaceControlItem.ts` type is minimal (missing `driver_number`, `flag`, `scope`, `lap_number` fields the API likely returns).
+
+**Fix:** Add typed interfaces for all API response shapes in `src/types/`. Use these in service functions as return types to get compile-time safety and better IDE completion. This also enables catching the `adaptRaceControlToTimeline` dropping of `category` at the type level.
+
+---
+
+### 22. In-Memory Rate Limiter is Not Cloudflare-Safe
+
+**Description:** `src/services/rateLimiter.ts` stores `timestamps` in a module-level array. Cloudflare Workers are isolated per-request (no shared memory between requests), so this rate limiter has no effect in production on Cloudflare Workers and only works locally.
+
+**Fix:** Move rate limiting state to Redis (e.g., an Upstash sliding window counter) or use Upstash's `@upstash/ratelimit` package, which is purpose-built for this pattern and works in edge/serverless environments.
+
+---
+
+### 23. Cache Key Collision Risk
+
+**Description:** In `races.ts`, when `sessionType` is provided, the Redis key is `racesResponse_session_type_${sessionType}`. This key holds all sessions of that type for the current year, but the key does not include the year. If the year rolls over during a 24h cache window, stale data from the prior year is served.
+
+**Fix:** Include `currentYear` in all cache keys: `racesResponse_year_${currentYear}_session_type_${sessionType}`.
+
+---
+
+### 24. Error Boundaries for Individual Cards
+
+**Description:** If `getWinnerByRace()` throws (e.g., the position API is temporarily unavailable), the entire home page server render fails because the error propagates through the RSC tree in `raceItem.tsx`. Currently there is only one top-level `error.tsx`.
+
+**Fix:** Wrap each `RaceItem` in a per-card Suspense + error boundary so a single failing card degrades gracefully while the rest of the grid renders.
+
+---
+
+## UX & Design Improvements
+
+### 25. Team Colour Accent per Driver
+
+**Description:** The drivers API returns `team_colour` as a hex string. Use it as the left-border stripe colour on `PitstopItem.tsx` instead of the uniform carbon border, and as the avatar background. This mirrors how real F1 timing towers are colour-coded.
+
+**File:** `src/components/pitstopItem.tsx`
+
+---
+
+### 26. Animated Live Ticker for Race Control Events
+
+**Description:** For live sessions, new race control messages currently appear only after `router.refresh()`. They pop in abruptly. Add a slide-in entrance animation (currently items use `opacity + translate-y` via `useIsVisible` — extend this to new-event detection) so fresh messages visually announce themselves.
+
+**File:** `src/components/raceControlItem.tsx`, `src/components/liveItem.tsx`
+
+---
+
+### 27. Mobile-First Card Layout Improvements
+
+**Description:** The home page grid is `grid-cols-1 lg:grid-cols-3`. On medium screens (tablets), it stays single-column which wastes horizontal space. Session detail tabs collapse to a `<select>` on mobile but the tab bar has no visual state indicator on desktop beyond an underline.
+
+**Fix:** Add `md:grid-cols-2` to the sessions grid. Enhance the tab active state with a subtle background fill, not just the red underline, for better affordance.
+
+---
+
+### 28. Skeleton Loader Polish
+
+**Description:** `src/utils/skeletons.tsx` and `skeleton2.tsx` exist but appear unused — the actual loading skeletons are inlined in `page.tsx` and `session/[id]/layout.tsx`. The inline skeletons are generic rectangles.
+
+**Fix:** Create purpose-built skeleton components matching the actual card layout (two-column data rows, image placeholder for flag, winner row), reducing visual layout shift when data loads.
+
+---
+
+### 29. Improved Empty State
+
+**Description:** When `racesOrdered?.length > 0` is false on the home page, nothing renders — no message, no illustration. A user filtering by "Sprint" with no sprint sessions in the current year sees a blank page.
+
+**File:** `src/app/page.tsx` line 74
+
+**Fix:** Add an `EmptyState` component with a contextual message: "No Sprint sessions found for {currentYear}" along with a button to reset the filter.
+
+---
+
+### 30. Keyboard Shortcuts for Tab Navigation
+
+**Description:** Power users and accessibility tools benefit from keyboard navigation. The tab switch in `tabs.tsx` uses `<Link>` which is accessible, but the session-type filter in `TabRaces.tsx` uses `<button>` with `router.push` — arrow key navigation between options is not implemented.
+
+**Fix:** Add `role="tablist"` / `role="tab"` ARIA semantics and `onKeyDown` handlers for left/right arrow keys on `TabRaces`, following the WAI-ARIA tab pattern. Headless UI (`@headlessui/react`, already installed) has a `Tab` component that handles this automatically.

--- a/src/services/__tests__/driver.test.ts
+++ b/src/services/__tests__/driver.test.ts
@@ -1,0 +1,145 @@
+import { getDriver } from "../driver";
+
+jest.mock("@upstash/redis", () => ({
+  Redis: {
+    fromEnv: jest.fn().mockReturnValue({
+      get: jest.fn(),
+      set: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock("../rateLimiter", () => ({
+  rateLimitedFetch: jest.fn(),
+}));
+
+import { Redis } from "@upstash/redis";
+import { rateLimitedFetch } from "../rateLimiter";
+
+const getRedis = () => (Redis.fromEnv as jest.Mock)();
+
+const API_ENDPOINT = "https://api.test/";
+
+const sampleDriver = {
+  driver_number: 44,
+  full_name: "Lewis Hamilton",
+  name_acronym: "HAM",
+  headshot_url: "https://example.com/ham.png",
+};
+
+beforeEach(() => {
+  process.env.API_ENDPOINT = API_ENDPOINT;
+  const redis = getRedis();
+  (redis.get as jest.Mock).mockReset();
+  (redis.set as jest.Mock).mockReset();
+  (rateLimitedFetch as jest.Mock).mockReset();
+});
+
+describe("getDriver", () => {
+  describe("cache hit", () => {
+    it("returns driver data from Redis when cache matches the query URL", async () => {
+      const cachedData = {
+        query: `${API_ENDPOINT}drivers?driver_number=44`,
+        data: sampleDriver,
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(cachedData));
+
+      const result = await getDriver(44);
+
+      expect(result).toEqual(sampleDriver);
+      expect(rateLimitedFetch).not.toHaveBeenCalled();
+    });
+
+    it("works with a string driver number", async () => {
+      const cachedData = {
+        query: `${API_ENDPOINT}drivers?driver_number=44`,
+        data: sampleDriver,
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(cachedData));
+
+      const result = await getDriver("44");
+
+      expect(result).toEqual(sampleDriver);
+    });
+
+    it("returns driver data when Redis returns an object (not a string)", async () => {
+      const cachedData = {
+        query: `${API_ENDPOINT}drivers?driver_number=44`,
+        data: sampleDriver,
+      };
+      getRedis().get.mockResolvedValue(cachedData);
+
+      const result = await getDriver(44);
+
+      expect(result).toEqual(sampleDriver);
+    });
+  });
+
+  describe("cache miss → API fetch", () => {
+    it("fetches from API, returns first element, and caches the result", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue([sampleDriver]),
+      });
+
+      const result = await getDriver(44);
+
+      expect(result).toEqual(sampleDriver);
+      expect(rateLimitedFetch).toHaveBeenCalledWith(
+        `${API_ENDPOINT}drivers?driver_number=44`,
+        { cache: "force-cache" }
+      );
+      expect(getRedis().set).toHaveBeenCalledWith(
+        "drivers_driver_number_44",
+        expect.stringContaining('"data"'),
+        { ex: 86400 }
+      );
+    });
+
+    it("returns undefined when API returns an empty array", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await getDriver(99);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("ignores stale cache when stored query doesn't match", async () => {
+      const staleCache = {
+        query: "https://old.api/drivers?driver_number=44",
+        data: { driver_number: 44, full_name: "Old Data" },
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(staleCache));
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue([sampleDriver]),
+      });
+
+      const result = await getDriver(44);
+
+      expect(result).toEqual(sampleDriver);
+      expect(rateLimitedFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns null when fetch throws", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+      const result = await getDriver(44);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when Redis throws", async () => {
+      getRedis().get.mockRejectedValue(new Error("Redis down"));
+
+      const result = await getDriver(44);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/services/__tests__/isSessionLive.test.ts
+++ b/src/services/__tests__/isSessionLive.test.ts
@@ -1,0 +1,75 @@
+import { isSessionLive } from "../isSessionLive";
+
+jest.mock("../races", () => ({
+  getRaces: jest.fn(),
+}));
+
+jest.mock("@/utils/isLiveSessionNow", () => jest.fn());
+
+const { getRaces } = require("../races");
+const isLiveSessionNow = require("@/utils/isLiveSessionNow");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("isSessionLive", () => {
+  it("returns true when the session is currently live", async () => {
+    getRaces.mockResolvedValue([
+      {
+        session_key: "9507",
+        date_start: "2024-03-02T14:00:00",
+        date_end: "2024-03-02T16:00:00",
+      },
+    ]);
+    isLiveSessionNow.mockReturnValue(true);
+
+    const result = await isSessionLive("9507");
+
+    expect(result).toBe(true);
+    expect(isLiveSessionNow).toHaveBeenCalledWith(
+      new Date("2024-03-02T14:00:00"),
+      new Date("2024-03-02T16:00:00")
+    );
+  });
+
+  it("returns false when the session has ended", async () => {
+    getRaces.mockResolvedValue([
+      {
+        session_key: "9507",
+        date_start: "2024-03-02T14:00:00",
+        date_end: "2024-03-02T16:00:00",
+      },
+    ]);
+    isLiveSessionNow.mockReturnValue(false);
+
+    const result = await isSessionLive("9507");
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when getRaces returns an empty array", async () => {
+    getRaces.mockResolvedValue([]);
+
+    const result = await isSessionLive("9507");
+
+    expect(result).toBe(false);
+    expect(isLiveSessionNow).not.toHaveBeenCalled();
+  });
+
+  it("returns false when getRaces returns null/undefined", async () => {
+    getRaces.mockResolvedValue(null);
+
+    const result = await isSessionLive("9507");
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when getRaces throws an error", async () => {
+    getRaces.mockRejectedValue(new Error("API failure"));
+
+    const result = await isSessionLive("9507");
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/services/__tests__/pitstops.test.ts
+++ b/src/services/__tests__/pitstops.test.ts
@@ -1,0 +1,154 @@
+import { getPitstops } from "../pitstops";
+
+jest.mock("@upstash/redis", () => ({
+  Redis: {
+    fromEnv: jest.fn().mockReturnValue({
+      get: jest.fn(),
+      set: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock("../rateLimiter", () => ({
+  rateLimitedFetch: jest.fn(),
+}));
+
+jest.mock("../isSessionLive", () => ({
+  isSessionLive: jest.fn(),
+}));
+
+jest.mock("../driver", () => ({
+  getDriver: jest.fn(),
+}));
+
+import { Redis } from "@upstash/redis";
+import { rateLimitedFetch } from "../rateLimiter";
+import { isSessionLive } from "../isSessionLive";
+import { getDriver } from "../driver";
+
+const getRedis = () => (Redis.fromEnv as jest.Mock)();
+
+const API_ENDPOINT = "https://api.test/";
+const SESSION_KEY = "9507";
+
+const samplePitstops = [
+  { driver_number: 44, lap_number: 10, pit_duration: "2.5" },
+  { driver_number: 55, lap_number: 15, pit_duration: "3.0" },
+];
+
+const driverHAM = { driver_number: 44, full_name: "Lewis Hamilton" };
+const driverSAI = { driver_number: 55, full_name: "Carlos Sainz" };
+
+beforeEach(() => {
+  process.env.API_ENDPOINT = API_ENDPOINT;
+  const redis = getRedis();
+  (redis.get as jest.Mock).mockReset();
+  (redis.set as jest.Mock).mockReset();
+  (rateLimitedFetch as jest.Mock).mockReset();
+  (isSessionLive as jest.Mock).mockReset();
+  (getDriver as jest.Mock).mockReset();
+});
+
+describe("getPitstops", () => {
+  describe("session is not live — cache path", () => {
+    beforeEach(() => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+    });
+
+    it("returns cached data when cache matches the query URL", async () => {
+      const enrichedData = samplePitstops.map((p) => ({
+        ...p,
+        driver: p.driver_number === 44 ? driverHAM : driverSAI,
+      }));
+      const cachedData = {
+        query: `${API_ENDPOINT}pit?session_key=${SESSION_KEY}`,
+        data: enrichedData,
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(cachedData));
+
+      const result = await getPitstops(SESSION_KEY);
+
+      expect(result).toEqual(enrichedData);
+      expect(rateLimitedFetch).not.toHaveBeenCalled();
+    });
+
+    it("fetches from API on cache miss, attaches driver data, and caches result", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue(samplePitstops),
+      });
+      (getDriver as jest.Mock).mockImplementation((num: number) =>
+        num === 44 ? Promise.resolve(driverHAM) : Promise.resolve(driverSAI)
+      );
+
+      const result = await getPitstops(SESSION_KEY);
+
+      expect(result).toEqual([
+        { driver_number: 44, lap_number: 10, pit_duration: "2.5", driver: driverHAM },
+        { driver_number: 55, lap_number: 15, pit_duration: "3.0", driver: driverSAI },
+      ]);
+      expect(getRedis().set).toHaveBeenCalledWith(
+        `pit_session_key_${SESSION_KEY}`,
+        expect.stringContaining('"data"'),
+        { ex: 86400 }
+      );
+    });
+
+    it("deduplicates driver fetches — calls getDriver once per unique driver number", async () => {
+      const multiplePitstopsForSameDriver = [
+        { driver_number: 44, lap_number: 10, pit_duration: "2.5" },
+        { driver_number: 44, lap_number: 30, pit_duration: "2.8" },
+      ];
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue(multiplePitstopsForSameDriver),
+      });
+      (getDriver as jest.Mock).mockResolvedValue(driverHAM);
+
+      await getPitstops(SESSION_KEY);
+
+      expect(getDriver).toHaveBeenCalledTimes(1);
+      expect(getDriver).toHaveBeenCalledWith(44);
+    });
+  });
+
+  describe("session is live — always fetches from API, skips cache write", () => {
+    beforeEach(() => {
+      (isSessionLive as jest.Mock).mockResolvedValue(true);
+    });
+
+    it("fetches from API without reading or writing Redis", async () => {
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue(samplePitstops),
+      });
+      (getDriver as jest.Mock).mockResolvedValue(driverHAM);
+
+      await getPitstops(SESSION_KEY);
+
+      expect(getRedis().get).not.toHaveBeenCalled();
+      expect(getRedis().set).not.toHaveBeenCalled();
+      expect(rateLimitedFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns an empty array when fetch throws", async () => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+      const result = await getPitstops(SESSION_KEY);
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns an empty array when Redis throws", async () => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+      getRedis().get.mockRejectedValue(new Error("Redis down"));
+
+      const result = await getPitstops(SESSION_KEY);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/services/__tests__/raceControl.test.ts
+++ b/src/services/__tests__/raceControl.test.ts
@@ -1,0 +1,163 @@
+import { getRaceControlBySession } from "../raceControl";
+
+jest.mock("@upstash/redis", () => ({
+  Redis: {
+    fromEnv: jest.fn().mockReturnValue({
+      get: jest.fn(),
+      set: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock("../rateLimiter", () => ({
+  rateLimitedFetch: jest.fn(),
+}));
+
+jest.mock("../isSessionLive", () => ({
+  isSessionLive: jest.fn(),
+}));
+
+import { Redis } from "@upstash/redis";
+import { rateLimitedFetch } from "../rateLimiter";
+import { isSessionLive } from "../isSessionLive";
+
+const getRedis = () => (Redis.fromEnv as jest.Mock)();
+
+const API_ENDPOINT = "https://api.test/";
+const SESSION_KEY = "9507";
+
+const sampleRaceControl = [
+  {
+    session_key: SESSION_KEY,
+    meeting_key: "1234",
+    date: "2024-03-02T14:05:00",
+    category: "Flag",
+    message: "GREEN FLAG",
+  },
+  {
+    session_key: SESSION_KEY,
+    meeting_key: "1234",
+    date: "2024-03-02T14:30:00",
+    category: "SafetyCar",
+    message: "SAFETY CAR DEPLOYED",
+  },
+];
+
+beforeEach(() => {
+  process.env.API_ENDPOINT = API_ENDPOINT;
+  const redis = getRedis();
+  (redis.get as jest.Mock).mockReset();
+  (redis.set as jest.Mock).mockReset();
+  (rateLimitedFetch as jest.Mock).mockReset();
+  (isSessionLive as jest.Mock).mockReset();
+});
+
+describe("getRaceControlBySession", () => {
+  describe("session is not live — cache path", () => {
+    beforeEach(() => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+    });
+
+    it("returns data from Redis when cache matches the query URL", async () => {
+      const cachedData = {
+        query: `${API_ENDPOINT}race_control?session_key=${SESSION_KEY}`,
+        data: sampleRaceControl,
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(cachedData));
+
+      const result = await getRaceControlBySession(SESSION_KEY);
+
+      expect(result).toEqual(sampleRaceControl);
+      expect(rateLimitedFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns data when Redis stores an object directly", async () => {
+      const cachedData = {
+        query: `${API_ENDPOINT}race_control?session_key=${SESSION_KEY}`,
+        data: sampleRaceControl,
+      };
+      getRedis().get.mockResolvedValue(cachedData);
+
+      const result = await getRaceControlBySession(SESSION_KEY);
+
+      expect(result).toEqual(sampleRaceControl);
+    });
+
+    it("fetches from API on cache miss and stores result in Redis", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue(sampleRaceControl),
+      });
+
+      const result = await getRaceControlBySession(SESSION_KEY);
+
+      expect(result).toEqual(sampleRaceControl);
+      expect(rateLimitedFetch).toHaveBeenCalledWith(
+        `${API_ENDPOINT}race_control?session_key=${SESSION_KEY}`
+      );
+      expect(getRedis().set).toHaveBeenCalledWith(
+        `race_control_session_key_${SESSION_KEY}`,
+        expect.stringContaining('"data"'),
+        { ex: 86400 }
+      );
+    });
+
+    it("fetches from API when cache query URL is stale", async () => {
+      const staleCache = {
+        query: "https://old-api.test/race_control?session_key=9999",
+        data: [],
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(staleCache));
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue(sampleRaceControl),
+      });
+
+      const result = await getRaceControlBySession(SESSION_KEY);
+
+      expect(result).toEqual(sampleRaceControl);
+      expect(rateLimitedFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("session is live — always fetches from API, skips cache read and write", () => {
+    beforeEach(() => {
+      (isSessionLive as jest.Mock).mockResolvedValue(true);
+    });
+
+    it("fetches from API without reading or writing Redis", async () => {
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue(sampleRaceControl),
+      });
+
+      const result = await getRaceControlBySession(SESSION_KEY);
+
+      expect(result).toEqual(sampleRaceControl);
+      expect(getRedis().get).not.toHaveBeenCalled();
+      expect(getRedis().set).not.toHaveBeenCalled();
+      expect(rateLimitedFetch).toHaveBeenCalledWith(
+        `${API_ENDPOINT}race_control?session_key=${SESSION_KEY}`
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns an empty array when fetch throws", async () => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+      const result = await getRaceControlBySession(SESSION_KEY);
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns an empty array when Redis throws", async () => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+      getRedis().get.mockRejectedValue(new Error("Redis down"));
+
+      const result = await getRaceControlBySession(SESSION_KEY);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/services/__tests__/races.test.ts
+++ b/src/services/__tests__/races.test.ts
@@ -1,0 +1,204 @@
+import { getRaces } from "../races";
+
+// Jest hoists jest.mock calls above imports. Using jest.fn() inline avoids
+// the "Cannot access before initialization" temporal dead zone issue.
+jest.mock("@upstash/redis", () => ({
+  Redis: {
+    fromEnv: jest.fn().mockReturnValue({
+      get: jest.fn(),
+      set: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock("../rateLimiter", () => ({
+  rateLimitedFetch: jest.fn(),
+}));
+
+import { Redis } from "@upstash/redis";
+import { rateLimitedFetch } from "../rateLimiter";
+
+const getRedis = () => (Redis.fromEnv as jest.Mock)();
+
+const API_ENDPOINT = "https://api.test/";
+const CURRENT_YEAR = new Date().getFullYear();
+
+beforeEach(() => {
+  process.env.API_ENDPOINT = API_ENDPOINT;
+  // Reset inner mock functions before each test
+  const redis = getRedis();
+  (redis.get as jest.Mock).mockReset();
+  (redis.set as jest.Mock).mockReset();
+  (rateLimitedFetch as jest.Mock).mockReset();
+});
+
+describe("getRaces", () => {
+  const sampleRaces = [
+    {
+      session_key: "9507",
+      date_start: "2024-03-02T14:00:00",
+      date_end: "2024-03-02T16:00:00",
+      location: "Bahrain",
+      session_type: "Race",
+    },
+  ];
+
+  describe("cache hit", () => {
+    it("returns data from Redis when cache key matches the query URL", async () => {
+      const cachedData = {
+        query: `${API_ENDPOINT}sessions?year=${CURRENT_YEAR}`,
+        data: sampleRaces,
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(cachedData));
+
+      const result = await getRaces({});
+
+      expect(result).toEqual(sampleRaces);
+      expect(rateLimitedFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns data from Redis when session key param matches", async () => {
+      const sessionKey = "9507";
+      const cachedData = {
+        query: `${API_ENDPOINT}sessions?year=${CURRENT_YEAR}&session_key=${sessionKey}`,
+        data: sampleRaces,
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(cachedData));
+
+      const result = await getRaces({ sessionKey });
+
+      expect(result).toEqual(sampleRaces);
+      expect(rateLimitedFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns data from Redis when session type param matches", async () => {
+      const sessionType = "Race";
+      const cachedData = {
+        query: `${API_ENDPOINT}sessions?year=${CURRENT_YEAR}&session_type=${sessionType}`,
+        data: sampleRaces,
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(cachedData));
+
+      const result = await getRaces({ sessionType });
+
+      expect(result).toEqual(sampleRaces);
+      expect(rateLimitedFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns data directly when Redis returns an object (not a string)", async () => {
+      const cachedData = {
+        query: `${API_ENDPOINT}sessions?year=${CURRENT_YEAR}`,
+        data: sampleRaces,
+      };
+      getRedis().get.mockResolvedValue(cachedData);
+
+      const result = await getRaces({});
+
+      expect(result).toEqual(sampleRaces);
+      expect(rateLimitedFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cache miss → API fetch", () => {
+    it("fetches from API when Redis returns null, caches the result", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(sampleRaces),
+      });
+
+      const result = await getRaces({});
+
+      expect(result).toEqual(sampleRaces);
+      expect(rateLimitedFetch).toHaveBeenCalledWith(
+        `${API_ENDPOINT}sessions?year=${CURRENT_YEAR}`
+      );
+      expect(getRedis().set).toHaveBeenCalledWith(
+        `racesResponse_year_${CURRENT_YEAR}`,
+        expect.stringContaining('"data"'),
+        { ex: 86400 }
+      );
+    });
+
+    it("uses session_key Redis key when sessionKey param is provided", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(sampleRaces),
+      });
+
+      await getRaces({ sessionKey: "9507" });
+
+      expect(rateLimitedFetch).toHaveBeenCalledWith(
+        `${API_ENDPOINT}sessions?year=${CURRENT_YEAR}&session_key=9507`
+      );
+      expect(getRedis().set).toHaveBeenCalledWith(
+        "racesResponse_session_key_9507",
+        expect.any(String),
+        { ex: 86400 }
+      );
+    });
+
+    it("uses session_type Redis key when sessionType param is provided", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(sampleRaces),
+      });
+
+      await getRaces({ sessionType: "Race" });
+
+      expect(rateLimitedFetch).toHaveBeenCalledWith(
+        `${API_ENDPOINT}sessions?year=${CURRENT_YEAR}&session_type=Race`
+      );
+      expect(getRedis().set).toHaveBeenCalledWith(
+        "racesResponse_session_type_Race",
+        expect.any(String),
+        { ex: 86400 }
+      );
+    });
+
+    it("ignores stale cache entry when the stored query URL doesn't match current params", async () => {
+      const staleCache = {
+        query: "https://old-api.test/sessions?year=2023",
+        data: [],
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(staleCache));
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(sampleRaces),
+      });
+
+      const result = await getRaces({});
+
+      expect(result).toEqual(sampleRaces);
+      expect(rateLimitedFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws when API returns a non-ok response", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: jest.fn().mockResolvedValue("Internal Server Error"),
+      });
+
+      await expect(getRaces({})).rejects.toThrow("API Error: 500");
+    });
+
+    it("throws when the fetch itself fails (network error)", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockRejectedValue(new Error("Network failure"));
+
+      await expect(getRaces({})).rejects.toThrow("Network failure");
+    });
+
+    it("throws when Redis get fails", async () => {
+      getRedis().get.mockRejectedValue(new Error("Redis connection refused"));
+
+      await expect(getRaces({})).rejects.toThrow("Redis connection refused");
+    });
+  });
+});

--- a/src/services/__tests__/winnerByRace.test.ts
+++ b/src/services/__tests__/winnerByRace.test.ts
@@ -1,0 +1,164 @@
+import { getWinnerByRace } from "../winnerByRace";
+
+jest.mock("@upstash/redis", () => ({
+  Redis: {
+    fromEnv: jest.fn().mockReturnValue({
+      get: jest.fn(),
+      set: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock("../rateLimiter", () => ({
+  rateLimitedFetch: jest.fn(),
+}));
+
+jest.mock("../isSessionLive", () => ({
+  isSessionLive: jest.fn(),
+}));
+
+jest.mock("../driver", () => ({
+  getDriver: jest.fn(),
+}));
+
+import { Redis } from "@upstash/redis";
+import { rateLimitedFetch } from "../rateLimiter";
+import { isSessionLive } from "../isSessionLive";
+import { getDriver } from "../driver";
+
+const getRedis = () => (Redis.fromEnv as jest.Mock)();
+
+const API_ENDPOINT = "https://api.test/";
+const SESSION_KEY = "9507";
+
+const samplePositionData = [
+  { driver_number: 44, position: 1, date: "2024-03-02T14:00:00" },
+  { driver_number: 44, position: 1, date: "2024-03-02T16:00:00" },
+];
+
+const winnerDriver = {
+  driver_number: 44,
+  full_name: "Lewis Hamilton",
+  name_acronym: "HAM",
+};
+
+beforeEach(() => {
+  process.env.API_ENDPOINT = API_ENDPOINT;
+  const redis = getRedis();
+  (redis.get as jest.Mock).mockReset();
+  (redis.set as jest.Mock).mockReset();
+  (rateLimitedFetch as jest.Mock).mockReset();
+  (isSessionLive as jest.Mock).mockReset();
+  (getDriver as jest.Mock).mockReset();
+});
+
+describe("getWinnerByRace", () => {
+  describe("session is not live — cache path", () => {
+    beforeEach(() => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+    });
+
+    it("returns winner with driver data from cache", async () => {
+      const QUERIES = `?session_key=${SESSION_KEY}&position<=1`;
+      const cachedData = {
+        query: `${API_ENDPOINT}position${QUERIES}`,
+        data: samplePositionData,
+      };
+      getRedis().get.mockResolvedValue(JSON.stringify(cachedData));
+      (getDriver as jest.Mock).mockResolvedValue(winnerDriver);
+
+      const result = await getWinnerByRace(SESSION_KEY);
+
+      expect(result.driver_number).toBe(44);
+      expect(result.driver).toEqual(winnerDriver);
+      expect(rateLimitedFetch).not.toHaveBeenCalled();
+    });
+
+    it("fetches from API on cache miss, caches result, and returns winner with driver", async () => {
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue(samplePositionData),
+      });
+      (getDriver as jest.Mock).mockResolvedValue(winnerDriver);
+
+      const result = await getWinnerByRace(SESSION_KEY);
+
+      expect(result.driver).toEqual(winnerDriver);
+      expect(getRedis().set).toHaveBeenCalledWith(
+        `position_session_key_${SESSION_KEY}_position_1`,
+        expect.stringContaining('"data"'),
+        { ex: 86400 }
+      );
+    });
+
+    it("returns last entry in position data as the winner (latest position record)", async () => {
+      const multiplePositions = [
+        { driver_number: 1, position: 1, date: "2024-03-02T14:00:00" },
+        { driver_number: 44, position: 1, date: "2024-03-02T16:00:00" },
+      ];
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue(multiplePositions),
+      });
+      (getDriver as jest.Mock).mockResolvedValue(winnerDriver);
+
+      const result = await getWinnerByRace(SESSION_KEY);
+
+      // at(-1) → last entry
+      expect(result.driver_number).toBe(44);
+    });
+  });
+
+  describe("session is live — always fetches from API", () => {
+    beforeEach(() => {
+      (isSessionLive as jest.Mock).mockResolvedValue(true);
+    });
+
+    it("fetches live data from API and returns winner with driver", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: jest.fn().mockResolvedValue(samplePositionData),
+      } as unknown as Response);
+      (getDriver as jest.Mock).mockResolvedValue(winnerDriver);
+
+      const result = await getWinnerByRace(SESSION_KEY);
+
+      expect(result.driver).toEqual(winnerDriver);
+      expect(getRedis().set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("empty race data", () => {
+    it("returns object with null driver when no position data exists", async () => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await getWinnerByRace(SESSION_KEY);
+
+      expect(result.driver).toBeNull();
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns object with null driver when fetch throws", async () => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+      getRedis().get.mockResolvedValue(null);
+      (rateLimitedFetch as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+      const result = await getWinnerByRace(SESSION_KEY);
+
+      expect(result).toEqual({ driver: null });
+    });
+
+    it("returns object with null driver when Redis throws", async () => {
+      (isSessionLive as jest.Mock).mockResolvedValue(false);
+      getRedis().get.mockRejectedValue(new Error("Redis down"));
+
+      const result = await getWinnerByRace(SESSION_KEY);
+
+      expect(result).toEqual({ driver: null });
+    });
+  });
+});

--- a/src/services/pitstop.test.ts
+++ b/src/services/pitstop.test.ts
@@ -1,56 +1,48 @@
-// Import jest under an alias so the global `jest` remains accessible
-// inside jest.mock() factories (which @swc/jest hoists before imports run).
-import { jest as jestGlobals } from "@jest/globals";
 import { getPitstops } from "./pitstops";
-import { getDriver } from "./driver";
 
 jest.mock("@upstash/redis", () => ({
   Redis: {
     fromEnv: jest.fn().mockReturnValue({
       get: jest.fn().mockResolvedValue(null),
       set: jest.fn().mockResolvedValue(undefined),
-      // Always grant a rate-limit slot so tests don't block on Redis.
       eval: jest.fn().mockResolvedValue(1),
     }),
   },
 }));
 
 jest.mock("./driver", () => ({
-  getDriver: jest.fn(),
+  getDriver: jest.fn().mockResolvedValue({ code: "DRV" }),
+}));
+
+jest.mock("./isSessionLive", () => ({
+  isSessionLive: jest.fn().mockResolvedValue(false),
 }));
 
 describe("getPitstops", () => {
-  let fetchSpy: jestGlobals.SpiedFunction<typeof fetch>;
-
   beforeEach(() => {
-    fetchSpy = jestGlobals.spyOn(global, "fetch");
-    (getDriver as jestGlobals.Mock).mockResolvedValue({ code: "DRV" });
-  });
-
-  afterEach(() => {
-    jestGlobals.restoreAllMocks();
-  });
-
-  it("returns parsed pit stop entries", async () => {
     process.env.API_ENDPOINT = "https://api.test/";
+    jest.clearAllMocks();
+  });
 
+  it("returns parsed pit stop entries with driver data attached", async () => {
     const sampleResponse = [
       { driver_number: 44, lap: 10 },
       { driver_number: 55, lap: 15 },
     ];
 
-    fetchSpy.mockResolvedValue({
-      ok: true,
+    global.fetch = jest.fn().mockResolvedValue({
       json: jest.fn().mockResolvedValue(sampleResponse),
     } as unknown as Response);
 
+    const { getDriver } = require("./driver");
+    getDriver.mockResolvedValue({ code: "DRV" });
+
     const data = await getPitstops("9507");
 
+    expect(Array.isArray(data)).toBe(true);
     expect(data).toEqual([
       { driver_number: 44, lap: 10, driver: { code: "DRV" } },
       { driver_number: 55, lap: 15, driver: { code: "DRV" } },
     ]);
-
-    expect(Array.isArray(data)).toBe(true);
   });
 });

--- a/src/utils/__tests__/adaptRaceControlToTimeline.test.ts
+++ b/src/utils/__tests__/adaptRaceControlToTimeline.test.ts
@@ -1,0 +1,71 @@
+import adaptRaceControlToTimeline from "../adaptRaceControlToTimeline";
+import { RaceControlTypeItem } from "@/types/RaceControlItem";
+
+const makeItem = (
+  message: string,
+  date: string,
+  category: string = "Flag"
+): RaceControlTypeItem => ({
+  session_key: "9507",
+  meeting_key: "1234",
+  date: new Date(date),
+  category,
+  message,
+});
+
+describe("adaptRaceControlToTimeline", () => {
+  it("maps race control items to timeline format", () => {
+    const items = [makeItem("GREEN FLAG", "2024-03-02T14:05:00")];
+
+    const result = adaptRaceControlToTimeline(items);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 0,
+      content: "GREEN FLAG",
+      datetime: new Date("2024-03-02T14:05:00"),
+      href: "#",
+      iconBackground: "bg-gray-400",
+    });
+    // date should be a formatted string
+    expect(typeof result[0].date).toBe("string");
+    expect(result[0].date.length).toBeGreaterThan(0);
+  });
+
+  it("assigns sequential ids starting from 0", () => {
+    const items = [
+      makeItem("GREEN FLAG", "2024-03-02T14:05:00"),
+      makeItem("SAFETY CAR", "2024-03-02T14:30:00"),
+      makeItem("SC IN", "2024-03-02T14:45:00"),
+    ];
+
+    const result = adaptRaceControlToTimeline(items);
+
+    expect(result[0].id).toBe(0);
+    expect(result[1].id).toBe(1);
+    expect(result[2].id).toBe(2);
+  });
+
+  it("preserves the message as content", () => {
+    const items = [
+      makeItem("SAFETY CAR DEPLOYED", "2024-03-02T14:30:00", "SafetyCar"),
+    ];
+
+    const result = adaptRaceControlToTimeline(items);
+
+    expect(result[0].content).toBe("SAFETY CAR DEPLOYED");
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(adaptRaceControlToTimeline([])).toEqual([]);
+  });
+
+  it("preserves the original date object as datetime", () => {
+    const date = "2024-03-02T14:05:00";
+    const items = [makeItem("GREEN FLAG", date)];
+
+    const result = adaptRaceControlToTimeline(items);
+
+    expect(result[0].datetime).toEqual(new Date(date));
+  });
+});

--- a/src/utils/__tests__/big.test.ts
+++ b/src/utils/__tests__/big.test.ts
@@ -1,0 +1,45 @@
+import { add } from "../big";
+
+describe("add", () => {
+  it("adds two integers", () => {
+    expect(add(1, 2)).toBe(3);
+    expect(add(0, 0)).toBe(0);
+    expect(add(100, 200)).toBe(300);
+  });
+
+  it("adds two decimal numbers precisely", () => {
+    expect(add(2.5, 3.0)).toBe(5.5);
+    expect(add(1.1, 2.2)).toBeCloseTo(3.3, 10);
+  });
+
+  it("adds a number and a string representation", () => {
+    expect(add(2.5, "3")).toBe(5.5);
+    expect(add("2.5", "3.0")).toBe(5.5);
+    expect(add("0", "0")).toBe(0);
+  });
+
+  it("handles pit-stop duration strings (typical use case)", () => {
+    expect(add(0, "2.5")).toBe(2.5);
+    expect(add(2.5, "3")).toBe(5.5);
+    expect(add(5.5, "4")).toBe(9.5);
+  });
+
+  it("handles numbers with different decimal lengths", () => {
+    expect(add(1.5, 2.25)).toBe(3.75);
+    expect(add("1.1", "2.22")).toBeCloseTo(3.32, 10);
+  });
+
+  it("handles large integers", () => {
+    expect(add(1000000, 2000000)).toBe(3000000);
+  });
+
+  it("returns a number type (not a string)", () => {
+    const result = add(1, 2);
+    expect(typeof result).toBe("number");
+  });
+
+  it("handles adding zero to a decimal", () => {
+    expect(add(0, "2.5")).toBe(2.5);
+    expect(add("2.5", 0)).toBe(2.5);
+  });
+});

--- a/src/utils/__tests__/classNames.test.ts
+++ b/src/utils/__tests__/classNames.test.ts
@@ -1,0 +1,41 @@
+import { classNames } from "../classNames";
+
+describe("classNames", () => {
+  it("joins multiple class strings with spaces", () => {
+    expect(classNames("foo", "bar", "baz")).toBe("foo bar baz");
+  });
+
+  it("filters out falsy values", () => {
+    expect(classNames("foo", false, "bar", null, undefined, 0, "baz")).toBe("foo bar baz");
+  });
+
+  it("returns an empty string when all values are falsy", () => {
+    expect(classNames(false, null, undefined, 0)).toBe("");
+  });
+
+  it("returns a single class with no extra spaces", () => {
+    expect(classNames("single")).toBe("single");
+  });
+
+  it("handles empty string arguments by filtering them out", () => {
+    // empty string is falsy
+    expect(classNames("", "foo")).toBe("foo");
+  });
+
+  it("returns empty string when called with no arguments", () => {
+    expect(classNames()).toBe("");
+  });
+
+  it("handles conditional class application pattern", () => {
+    const isActive = true;
+    const isDisabled = false;
+
+    const result = classNames(
+      "base",
+      isActive && "active",
+      isDisabled && "disabled"
+    );
+
+    expect(result).toBe("base active");
+  });
+});

--- a/src/utils/__tests__/isLiveSessionNow.test.ts
+++ b/src/utils/__tests__/isLiveSessionNow.test.ts
@@ -1,0 +1,63 @@
+import isLiveSessionNow from "../isLiveSessionNow";
+
+describe("isLiveSessionNow", () => {
+  const fixedNow = new Date("2024-03-02T15:00:00.000Z");
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(fixedNow);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns true when current time is between session start and end on the same day", () => {
+    const start = new Date("2024-03-02T14:00:00.000Z");
+    const end = new Date("2024-03-02T16:00:00.000Z");
+
+    expect(isLiveSessionNow(start, end)).toBe(true);
+  });
+
+  it("returns false when current time is before session start", () => {
+    const start = new Date("2024-03-02T16:00:00.000Z");
+    const end = new Date("2024-03-02T18:00:00.000Z");
+
+    expect(isLiveSessionNow(start, end)).toBe(false);
+  });
+
+  it("returns false when current time is after session end", () => {
+    const start = new Date("2024-03-02T12:00:00.000Z");
+    const end = new Date("2024-03-02T14:00:00.000Z");
+
+    expect(isLiveSessionNow(start, end)).toBe(false);
+  });
+
+  it("returns false when session is on a different day (yesterday)", () => {
+    const start = new Date("2024-03-01T14:00:00.000Z");
+    const end = new Date("2024-03-01T16:00:00.000Z");
+
+    expect(isLiveSessionNow(start, end)).toBe(false);
+  });
+
+  it("returns false when session is on a different day (tomorrow)", () => {
+    const start = new Date("2024-03-03T14:00:00.000Z");
+    const end = new Date("2024-03-03T16:00:00.000Z");
+
+    expect(isLiveSessionNow(start, end)).toBe(false);
+  });
+
+  it("returns false when session is in a different month", () => {
+    const start = new Date("2024-04-02T14:00:00.000Z");
+    const end = new Date("2024-04-02T16:00:00.000Z");
+
+    expect(isLiveSessionNow(start, end)).toBe(false);
+  });
+
+  it("returns false when session is in a different year", () => {
+    const start = new Date("2023-03-02T14:00:00.000Z");
+    const end = new Date("2023-03-02T16:00:00.000Z");
+
+    expect(isLiveSessionNow(start, end)).toBe(false);
+  });
+});

--- a/src/utils/__tests__/orderRaceControl.test.ts
+++ b/src/utils/__tests__/orderRaceControl.test.ts
@@ -1,0 +1,51 @@
+import { orderRaceControl } from "../orderRaceControl";
+import { RaceControlTypeItem } from "@/types/RaceControlItem";
+
+const makeItem = (date: string): RaceControlTypeItem => ({
+  session_key: "9507",
+  meeting_key: "1234",
+  date: new Date(date),
+  category: "Flag",
+  message: `Event at ${date}`,
+});
+
+describe("orderRaceControl", () => {
+  it("sorts items in descending date order (newest first)", () => {
+    const items = [
+      makeItem("2024-03-02T14:00:00"),
+      makeItem("2024-03-02T16:00:00"),
+      makeItem("2024-03-02T15:00:00"),
+    ];
+
+    const result = orderRaceControl(items);
+
+    expect(result[0].date).toEqual(new Date("2024-03-02T16:00:00"));
+    expect(result[1].date).toEqual(new Date("2024-03-02T15:00:00"));
+    expect(result[2].date).toEqual(new Date("2024-03-02T14:00:00"));
+  });
+
+  it("returns an empty array when given an empty array", () => {
+    expect(orderRaceControl([])).toEqual([]);
+  });
+
+  it("returns the same single item unchanged", () => {
+    const items = [makeItem("2024-03-02T14:00:00")];
+    const result = orderRaceControl(items);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toEqual(new Date("2024-03-02T14:00:00"));
+  });
+
+  it("handles items already in descending order", () => {
+    const items = [
+      makeItem("2024-03-02T16:00:00"),
+      makeItem("2024-03-02T15:00:00"),
+      makeItem("2024-03-02T14:00:00"),
+    ];
+
+    const result = orderRaceControl(items);
+
+    expect(result[0].date).toEqual(new Date("2024-03-02T16:00:00"));
+    expect(result[2].date).toEqual(new Date("2024-03-02T14:00:00"));
+  });
+});

--- a/src/utils/__tests__/orderRacesByLastest.test.ts
+++ b/src/utils/__tests__/orderRacesByLastest.test.ts
@@ -1,0 +1,79 @@
+import { orderRacesLastest } from "../orderRacesByLastest";
+import { RaceItemType } from "@/types/RaceItemType";
+
+const makeRace = (
+  sessionType: string,
+  dateStart: string,
+  sessionKey: string = "1"
+): RaceItemType => ({
+  session_key: sessionKey,
+  date_start: new Date(dateStart),
+  date_end: new Date(dateStart),
+  location: "Test Circuit",
+  country_name: "Testland",
+  country_code: "TST",
+  circuit_short_name: "TST",
+  session_name: sessionType,
+  session_type: sessionType,
+});
+
+const races: RaceItemType[] = [
+  makeRace("Race", "2024-03-02T14:00:00", "1"),
+  makeRace("Qualifying", "2024-03-01T14:00:00", "2"),
+  makeRace("Race", "2024-04-07T14:00:00", "3"),
+  makeRace("Sprint", "2024-04-06T14:00:00", "4"),
+  makeRace("Race", "2024-05-05T14:00:00", "5"),
+];
+
+describe("orderRacesLastest", () => {
+  it("filters races by session type (default 'Race') and returns up to 3 sorted ascending", () => {
+    const result = orderRacesLastest(races);
+
+    expect(result).toHaveLength(3);
+    result.forEach((r) => expect(r.session_type).toBe("Race"));
+    // ascending by date
+    expect(result[0].session_key).toBe("1");
+    expect(result[1].session_key).toBe("3");
+    expect(result[2].session_key).toBe("5");
+  });
+
+  it("uses a custom filter type", () => {
+    const result = orderRacesLastest(races, "Qualifying");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].session_key).toBe("2");
+  });
+
+  it("uses a custom limit", () => {
+    const result = orderRacesLastest(races, "Race", 2);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns all matching items when limit exceeds available items", () => {
+    const result = orderRacesLastest(races, "Race", 100);
+
+    // only 3 Race sessions exist
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns an empty array when no sessions match the filter", () => {
+    const result = orderRacesLastest(races, "Practice");
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    const result = orderRacesLastest([]);
+
+    expect(result).toEqual([]);
+  });
+
+  it("sorts ascending by date_start", () => {
+    const result = orderRacesLastest(races, "Race", 3);
+
+    const dates = result.map((r) => new Date(r.date_start).getTime());
+    expect(dates[0]).toBeLessThan(dates[1]);
+    expect(dates[1]).toBeLessThan(dates[2]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `jest.config.js` missing `moduleNameMapper` for `@/*` path alias (previously breaking test suite)
- Rewrite `src/services/pitstop.test.ts` to use standard Jest globals and properly mock `isSessionLive`
- Add 84 unit tests across 14 suites covering all services and utility functions
- Add `IMPROVEMENTS.md` with 30 prioritized feature and technical improvement ideas

## Test coverage added

**Services** (`src/services/__tests__/`):
- `races.test.ts` — cache hit/miss, API fetch, Redis store, error paths
- `driver.test.ts` — cache hit/miss, empty responses, error handling
- `raceControl.test.ts` — live vs non-live session branching, cache, error paths
- `pitstops.test.ts` — cache, driver enrichment, deduplication, live bypass
- `winnerByRace.test.ts` — cache, winner selection logic, live path
- `isSessionLive.test.ts` — true/false/null/empty/throws scenarios

**Utilities** (`src/utils/__tests__/`):
- `isLiveSessionNow.test.ts`, `big.test.ts`, `classNames.test.ts`, `orderRaceControl.test.ts`, `orderRacesByLastest.test.ts`, `adaptRaceControlToTimeline.test.ts`

## Test plan

- [x] `pnpm test` — all 84 tests pass across 14 suites
- [x] `pnpm build` — clean build, no TypeScript errors
- [x] No real network or Redis calls (all mocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)