### PR TITLE
feat: add year selector to filter F1 sessions by competition year

### DIFF
--- a/docs/YEAR-SELECTOR.md
+++ b/docs/YEAR-SELECTOR.md
@@ -1,0 +1,121 @@
+# Year Selector
+
+## Feature Overview
+
+The year selector lets users filter the session listing by F1 competition year. Selecting a year sets a `?year=YYYY` query parameter; the service layer passes it to the external API and caches the result under a year-scoped Redis key. Without a selection, the app defaults to the current calendar year — the same behavior as before this feature was added.
+
+---
+
+## URL Parameter
+
+| Parameter | Example | Default |
+|---|---|---|
+| `year` | `?year=2024` | Current calendar year |
+| `sessionType` | `?sessionType=Race` | All types |
+
+Both parameters coexist on the same URL and are preserved independently:
+
+```
+/?year=2024&sessionType=Race
+```
+
+- Selecting "ALL" in the year selector removes `year` from the URL (reverts to current year).
+- Selecting a session type tab preserves any active `year` param.
+- Selecting a year button preserves any active `sessionType` param.
+
+---
+
+## Architecture
+
+Three files are involved.
+
+### `src/services/races.ts`
+
+Owns all data-fetching logic. The `GetRaceType` interface accepts an optional `year`:
+
+```ts
+interface GetRaceType {
+  sessionKey?: string;
+  sessionType?: string;
+  year?: number;
+}
+```
+
+When `year` is omitted, the service falls back to the current year:
+
+```ts
+const year = params.year ?? new Date().getFullYear();
+```
+
+The resolved year is used in:
+- The Redis cache key: `racesResponse_year_${year}`
+- The API query string: `?year=${year}`
+
+No other service logic changes — Redis lookup, fetch fallback, error handling, and TTL are all unchanged.
+
+### `src/components/yearSelector.tsx`
+
+Client component (`"use client"`) responsible for rendering the year filter buttons.
+
+| Prop | Type | Description |
+|---|---|---|
+| `years` | `number[]` | List of years to render as buttons |
+
+Reads the active year from `useSearchParams` and uses `useRouter` to navigate on button click. URL construction uses a `URLSearchParams`-based `buildUrl` helper that preserves or removes the `sessionType` param as appropriate.
+
+Styled to match `tabRaces.tsx`: `font-data text-[10px] tracking-[0.25em] uppercase`, active state uses `bg-f1red border-f1red text-white`, inactive state uses `border-carbon-border text-muted`.
+
+### `src/app/page.tsx`
+
+Server component. Reads `year` from the awaited `searchParams`:
+
+```ts
+const year = Number(searchParamsAwaited.year) || undefined;
+```
+
+Passes `year` to `getRaces`:
+
+```ts
+const races = await getRaces({ sessionType, year });
+```
+
+Renders `<YearSelector>` inside a `<Suspense>` boundary (required because the component uses `useSearchParams`), placed above `<TabRaces>`:
+
+```tsx
+<Suspense>
+  <YearSelector years={[2023, 2024, 2025, 2026]} />
+</Suspense>
+```
+
+---
+
+## Caching Behavior
+
+Each year gets its own Redis cache entry:
+
+| Year | Cache key |
+|---|---|
+| 2023 | `racesResponse_year_2023` |
+| 2024 | `racesResponse_year_2024` |
+| 2025 | `racesResponse_year_2025` |
+| 2026 | `racesResponse_year_2026` |
+
+- TTL is **86400 seconds (24 hours)**, defined in `src/services/cache.ts`.
+- Live sessions bypass the cache entirely regardless of year. `isSessionLive()` returning `true` triggers a direct API fetch with no Redis read or write.
+
+---
+
+## Adding a New Year
+
+The `years` array is hardcoded in `src/app/page.tsx`. To expose a new season:
+
+1. Open `src/app/page.tsx`.
+2. Update the array passed to `<YearSelector>`:
+
+```tsx
+<YearSelector years={[2023, 2024, 2025, 2026, 2027]} />
+```
+
+That is the only change required. The service layer and component accept any year value automatically.
+
+> Keep years in ascending order — the component renders them in the order provided.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,8 @@ const Home = async ({ searchParams }: any) => {
   const sessionType = searchParamsAwaited?.sessionType
     ? (searchParamsAwaited?.sessionType as string)
     : undefined;
-  const year = searchParamsAwaited?.year ? Number(searchParamsAwaited.year) : undefined;
+  const parsedYear = Number(searchParamsAwaited?.year);
+  const year = Number.isInteger(parsedYear) && parsedYear > 0 ? parsedYear : undefined;
   const races = await getRaces({ sessionType, year });
   const racesOrdered = orderRacesLastest(
     races,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { FlagValues } from "@vercel/flags/react";
 import { getFlags } from "./getFlags";
 import { orderRacesLastest } from "@/utils/orderRacesByLastest";
 import TabRaces from "@/components/tabRaces";
+import YearSelector from "@/components/yearSelector";
 
 export const revalidate = 3600;
 
@@ -22,7 +23,8 @@ const Home = async ({ searchParams }: any) => {
   const sessionType = searchParamsAwaited?.sessionType
     ? (searchParamsAwaited?.sessionType as string)
     : undefined;
-  const races = await getRaces({ sessionType });
+  const year = searchParamsAwaited?.year ? Number(searchParamsAwaited.year) : undefined;
+  const races = await getRaces({ sessionType, year });
   const racesOrdered = orderRacesLastest(
     races,
     sessionType,
@@ -39,6 +41,21 @@ const Home = async ({ searchParams }: any) => {
       </Suspense>
 
       {values.showSearchInput && <SearchInput />}
+
+      <Suspense
+        fallback={
+          <div className="flex gap-1 mb-4">
+            {[...Array(5)].map((_, i) => (
+              <div
+                key={i}
+                className="h-8 w-16 bg-carbon-mid animate-pulse"
+              />
+            ))}
+          </div>
+        }
+      >
+        <YearSelector years={[2023, 2024, 2025, 2026]} />
+      </Suspense>
 
       <Suspense
         fallback={

--- a/src/components/tabRaces.tsx
+++ b/src/components/tabRaces.tsx
@@ -10,6 +10,15 @@ export default function TabRaces(props: TabRacesProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const activeSessionType = searchParams.get("sessionType");
+  const year = searchParams.get("year");
+
+  const buildUrl = (sessionType?: string) => {
+    const params = new URLSearchParams();
+    if (year) params.set("year", year);
+    if (sessionType) params.set("sessionType", sessionType);
+    const qs = params.toString();
+    return qs ? `/?${qs}` : "/";
+  };
 
   return (
     <div className="flex items-center gap-1 mb-8">
@@ -19,7 +28,7 @@ export default function TabRaces(props: TabRacesProps) {
             ? "bg-f1red border-f1red text-white"
             : "border-carbon-border text-muted hover:border-muted hover:text-chromium bg-transparent"
         }`}
-        onClick={() => router.push("/")}
+        onClick={() => router.push(buildUrl())}
       >
         ALL
       </button>
@@ -31,7 +40,7 @@ export default function TabRaces(props: TabRacesProps) {
               ? "bg-f1red border-f1red text-white"
               : "border-carbon-border text-muted hover:border-muted hover:text-chromium bg-transparent"
           }`}
-          onClick={() => router.push("?sessionType=" + sessionType)}
+          onClick={() => router.push(buildUrl(sessionType))}
         >
           {sessionType}
         </button>

--- a/src/components/yearSelector.tsx
+++ b/src/components/yearSelector.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+interface YearSelectorProps {
+  years: number[];
+}
+
+export default function YearSelector(props: YearSelectorProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const activeYear = searchParams.get("year");
+  const sessionType = searchParams.get("sessionType");
+
+  const buildUrl = (year?: number) => {
+    const params = new URLSearchParams();
+    if (sessionType) params.set("sessionType", sessionType);
+    if (year !== undefined) params.set("year", String(year));
+    const query = params.toString();
+    return query ? `/?${query}` : "/";
+  };
+
+  return (
+    <div className="flex items-center gap-1 mb-4">
+      <button
+        className={`font-data text-[10px] tracking-[0.25em] uppercase px-4 py-2 transition-all duration-200 border ${
+          !activeYear
+            ? "bg-f1red border-f1red text-white"
+            : "border-carbon-border text-muted hover:border-muted hover:text-chromium bg-transparent"
+        }`}
+        onClick={() => router.push(buildUrl())}
+      >
+        ALL
+      </button>
+      {props.years.map((year) => (
+        <button
+          key={year}
+          className={`font-data text-[10px] tracking-[0.25em] uppercase px-4 py-2 transition-all duration-200 border ${
+            activeYear === String(year)
+              ? "bg-f1red border-f1red text-white"
+              : "border-carbon-border text-muted hover:border-muted hover:text-chromium bg-transparent"
+          }`}
+          onClick={() => router.push(buildUrl(year))}
+        >
+          {year}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/services/races.test.ts
+++ b/src/services/races.test.ts
@@ -1,0 +1,232 @@
+import { getRaces } from "@/services/races";
+import { currentYear } from "@/utils/constants";
+import { Redis } from "@upstash/redis";
+
+jest.mock("@upstash/redis", () => ({
+  Redis: {
+    fromEnv: jest.fn().mockReturnValue({
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      eval: jest.fn().mockResolvedValue(1),
+    }),
+  },
+}));
+
+const mockRaces = [
+  {
+    session_key: "9507",
+    location: "Bahrain",
+    session_name: "Race",
+    session_type: "Race",
+    date_start: "2024-03-02T15:00:00+00:00",
+    date_end: "2024-03-02T17:00:00+00:00",
+    country_name: "Bahrain",
+    country_code: "BH",
+    circuit_short_name: "Bahrain",
+  },
+];
+
+function getRedisMock() {
+  return Redis.fromEnv() as {
+    get: jest.Mock;
+    set: jest.Mock;
+    eval: jest.Mock;
+  };
+}
+
+describe("getRaces", () => {
+  beforeEach(() => {
+    process.env.API_ENDPOINT = "https://api.example.com/";
+    jest.clearAllMocks();
+    // Rate limiter: acquireSlot always grants immediately
+    getRedisMock().eval.mockResolvedValue(1);
+    // Default: cache miss
+    getRedisMock().get.mockResolvedValue(null);
+    getRedisMock().set.mockResolvedValue(undefined);
+    jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockRaces,
+      headers: { get: () => null },
+    } as unknown as Response);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("default year behavior", () => {
+    it("uses currentYear in the cache key when no params are passed", async () => {
+      await getRaces({});
+
+      const expectedKey = `racesResponse_year_${currentYear}`;
+      expect(getRedisMock().get).toHaveBeenCalledWith(expectedKey);
+    });
+
+    it("uses currentYear in the API URL when no params are passed", async () => {
+      await getRaces({});
+
+      const expectedUrl = `https://api.example.com/sessions?year=${currentYear}`;
+      expect(global.fetch).toHaveBeenCalledWith(expectedUrl, undefined);
+    });
+
+    it("returns data from the API response", async () => {
+      const result = await getRaces({});
+
+      expect(result).toEqual(mockRaces);
+    });
+  });
+
+  describe("cache hit", () => {
+    it("returns cached data without calling fetch when cache key and query match", async () => {
+      const expectedUrl = `https://api.example.com/sessions?year=${currentYear}`;
+      const cachedPayload = JSON.stringify({
+        query: expectedUrl,
+        data: mockRaces,
+      });
+      getRedisMock().get.mockResolvedValue(cachedPayload);
+
+      const result = await getRaces({});
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result).toEqual(mockRaces);
+    });
+
+    it("does not write to Redis when returning from cache", async () => {
+      const expectedUrl = `https://api.example.com/sessions?year=${currentYear}`;
+      const cachedPayload = JSON.stringify({
+        query: expectedUrl,
+        data: mockRaces,
+      });
+      getRedisMock().get.mockResolvedValue(cachedPayload);
+
+      await getRaces({});
+
+      expect(getRedisMock().set).not.toHaveBeenCalled();
+    });
+
+    it("falls through to fetch when cached query URL does not match current URL", async () => {
+      // Cache has a stale entry pointing to a different URL
+      const stalePayload = JSON.stringify({
+        query: "https://api.example.com/sessions?year=2020",
+        data: [],
+      });
+      getRedisMock().get.mockResolvedValue(stalePayload);
+
+      await getRaces({});
+
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("cache miss", () => {
+    it("calls fetch when Redis returns null", async () => {
+      getRedisMock().get.mockResolvedValue(null);
+
+      await getRaces({});
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("stores fetched data in Redis after a cache miss", async () => {
+      getRedisMock().get.mockResolvedValue(null);
+
+      await getRaces({});
+
+      expect(getRedisMock().set).toHaveBeenCalledTimes(1);
+      const [cacheKey, storedValue] = getRedisMock().set.mock.calls[0];
+      expect(cacheKey).toBe(`racesResponse_year_${currentYear}`);
+      const parsed = JSON.parse(storedValue);
+      expect(parsed.data).toEqual(mockRaces);
+      expect(parsed.query).toBe(
+        `https://api.example.com/sessions?year=${currentYear}`
+      );
+    });
+
+    it("stores result in Redis with TTL option set", async () => {
+      await getRaces({});
+
+      const [, , options] = getRedisMock().set.mock.calls[0];
+      expect(options).toHaveProperty("ex");
+      expect(typeof options.ex).toBe("number");
+      expect(options.ex).toBeGreaterThan(0);
+    });
+  });
+
+  describe("API error handling", () => {
+    it("throws an error when response.ok is false", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => "Internal Server Error",
+        headers: { get: () => null },
+      } as unknown as Response);
+
+      await expect(getRaces({})).rejects.toThrow("API Error: 500");
+    });
+
+    it("throws an error including the status code when response.ok is false", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: async () => "Not Found",
+        headers: { get: () => null },
+      } as unknown as Response);
+
+      await expect(getRaces({})).rejects.toThrow("404");
+    });
+
+    it("re-throws errors from fetch", async () => {
+      jest.spyOn(global, "fetch").mockRejectedValue(new Error("Network error"));
+
+      await expect(getRaces({})).rejects.toThrow("Network error");
+    });
+  });
+
+  describe("sessionType param", () => {
+    it("appends sessionType to the query string", async () => {
+      await getRaces({ sessionType: "Race" });
+
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain("session_type=Race");
+    });
+
+    it("uses a sessionType-specific cache key", async () => {
+      await getRaces({ sessionType: "Qualifying" });
+
+      expect(getRedisMock().get).toHaveBeenCalledWith(
+        "racesResponse_session_type_Qualifying"
+      );
+    });
+
+    it("still includes the year param in the URL when sessionType is set", async () => {
+      await getRaces({ sessionType: "Sprint" });
+
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain(`year=${currentYear}`);
+    });
+
+    it("returns data from the API when sessionType is provided", async () => {
+      const result = await getRaces({ sessionType: "Race" });
+
+      expect(result).toEqual(mockRaces);
+    });
+  });
+
+  describe("sessionKey param", () => {
+    it("appends session_key to the query string", async () => {
+      await getRaces({ sessionKey: "9507" });
+
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain("session_key=9507");
+    });
+
+    it("uses a sessionKey-specific cache key", async () => {
+      await getRaces({ sessionKey: "9507" });
+
+      expect(getRedisMock().get).toHaveBeenCalledWith(
+        "racesResponse_session_key_9507"
+      );
+    });
+  });
+});

--- a/src/services/races.ts
+++ b/src/services/races.ts
@@ -10,7 +10,7 @@ interface GetRaceType {
 }
 
 export const getRaces = async (params: GetRaceType) => {
-  const year = params.year ?? currentYear;
+  const year = (Number.isInteger(params.year) && params.year! > 0) ? params.year! : currentYear;
   let key = `racesResponse_year_${year}`
   const API_ENDPOINT = process.env.API_ENDPOINT;
   const redis = Redis.fromEnv();

--- a/src/services/races.ts
+++ b/src/services/races.ts
@@ -6,15 +6,17 @@ import { rateLimitedFetch } from "./rateLimiter";
 interface GetRaceType {
   sessionKey?: string;
   sessionType?: string;
+  year?: number;
 }
 
 export const getRaces = async (params: GetRaceType) => {
-  let key = `racesResponse_year_${currentYear}`
+  const year = params.year ?? currentYear;
+  let key = `racesResponse_year_${year}`
   const API_ENDPOINT = process.env.API_ENDPOINT;
   const redis = Redis.fromEnv();
 
   const SERVICE = "sessions";
-  let QUERIES = `?year=${currentYear}`;
+  let QUERIES = `?year=${year}`;
   if (params.sessionKey) {
     QUERIES += "&session_key=" + params.sessionKey;
     key = `racesResponse_session_key_${params.sessionKey}`


### PR DESCRIPTION
## Summary

- Adds `YearSelector` client component rendering year buttons (2023–2026) + ALL, styled to match the existing `TabRaces` component
- Updates `getRaces` service to accept an optional `year` param (defaults to current year); each year gets its own Redis cache key
- Updates home page to read `?year=YYYY` from search params and pass it to the service and selector
- Adds 18 unit/integration tests for the updated `getRaces` service
- Adds `docs/YEAR-SELECTOR.md` covering architecture, caching behavior, URL params, and how to add new years

## Test plan

- [ ] Visit the home page and verify year buttons (ALL, 2023, 2024, 2025, 2026) appear above session type tabs
- [ ] Click a year button and confirm URL updates to `?year=YYYY` and sessions filter to that year
- [ ] Combine year + session type filters and confirm both params are preserved in the URL
- [ ] Click ALL to confirm year param is cleared and current year sessions are shown
- [ ] Run `pnpm test src/services/races.test.ts` — all 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)